### PR TITLE
Feature/371 upload media designated directory

### DIFF
--- a/analogwp-templates.php
+++ b/analogwp-templates.php
@@ -28,7 +28,7 @@ define( 'ANG_PLUGIN_FILE', __FILE__ );
 define( 'ANG_PLUGIN_URL', plugin_dir_url( ANG_PLUGIN_FILE ) );
 define( 'ANG_PLUGIN_DIR', plugin_dir_path( ANG_PLUGIN_FILE ) );
 define( 'ANG_PLUGIN_BASE', plugin_basename( ANG_PLUGIN_FILE ) );
-define( 'ANG_SK_UPLOAD_DIR', '/style_kits');
+define( 'ANG_SK_UPLOAD_DIR', '/style_kits' );
 
 /**
  * Handles plugin activation.

--- a/analogwp-templates.php
+++ b/analogwp-templates.php
@@ -28,6 +28,7 @@ define( 'ANG_PLUGIN_FILE', __FILE__ );
 define( 'ANG_PLUGIN_URL', plugin_dir_url( ANG_PLUGIN_FILE ) );
 define( 'ANG_PLUGIN_DIR', plugin_dir_path( ANG_PLUGIN_FILE ) );
 define( 'ANG_PLUGIN_BASE', plugin_basename( ANG_PLUGIN_FILE ) );
+define( 'ANG_SK_UPLOAD_DIR', '/style_kits');
 
 /**
  * Handles plugin activation.

--- a/inc/Utils.php
+++ b/inc/Utils.php
@@ -775,7 +775,12 @@ class Utils extends Base {
 	 * @return Array
 	 */
 	public static function style_kits_upload_dir( $arr ) {
+		global $global_subdirectory_name;
 		$folder = ANG_SK_UPLOAD_DIR;
+
+		if ( ! empty( $global_subdirectory_name ) ) {
+			$folder .= '/' . $global_subdirectory_name;
+		}
 
 		$arr['path']   = $arr['basedir'] . $folder;
 		$arr['url']    = $arr['baseurl'] . $folder;

--- a/inc/Utils.php
+++ b/inc/Utils.php
@@ -768,11 +768,11 @@ class Utils extends Base {
 	 *
 	 * This static method is responsible to filter and modify the uploaded file path to plugin defined constant path.
 	 *
-	 * @since 1.6.10
+	 * @since n.e.x.t
 	 *
-	 * @param Array $arr An associative array which holds upload path configuration.
+	 * @param array $arr An associative array which holds upload path configuration.
 	 *
-	 * @return Array
+	 * @return array
 	 */
 	public static function style_kits_upload_dir( $arr ) {
 		global $global_subdirectory_name;

--- a/inc/Utils.php
+++ b/inc/Utils.php
@@ -796,6 +796,27 @@ class Utils extends Base {
 
 		return $tab;
 	}
+
+	/**
+	 * Filters upload files path and URL
+	 *
+	 * This static method is responsible to filter and modify the uploaded file path to plugin defined constant path.
+	 *
+	 * @since 1.6.10
+	 *
+	 * @param Array $arr An associative array which holds upload path configuration.
+	 *
+	 * @return Array
+	 */
+	public static function style_kits_upload_dir( $arr ) {
+		$folder = ANG_SK_UPLOAD_DIR;
+
+		$arr['path']   = $arr['basedir'] . $folder;
+		$arr['url']    = $arr['baseurl'] . $folder;
+		$arr['subdir'] = $folder;
+
+		return $arr;
+	}
 }
 
 new Utils();

--- a/inc/Utils.php
+++ b/inc/Utils.php
@@ -764,6 +764,27 @@ class Utils extends Base {
 	}
 
 	/**
+	 * Filters upload files path and URL
+	 *
+	 * This static method is responsible to filter and modify the uploaded file path to plugin defined constant path.
+	 *
+	 * @since 1.6.10
+	 *
+	 * @param Array $arr An associative array which holds upload path configuration.
+	 *
+	 * @return Array
+	 */
+	public static function style_kits_upload_dir( $arr ) {
+		$folder = ANG_SK_UPLOAD_DIR;
+
+		$arr['path']   = $arr['basedir'] . $folder;
+		$arr['url']    = $arr['baseurl'] . $folder;
+		$arr['subdir'] = $folder;
+
+		return $arr;
+	}
+
+	/**
 	 * Check if the installed version of Elementor is older than a specified version.
 	 *
 	 * @param string $version Version number.
@@ -795,27 +816,6 @@ class Utils extends Base {
 		}
 
 		return $tab;
-	}
-
-	/**
-	 * Filters upload files path and URL
-	 *
-	 * This static method is responsible to filter and modify the uploaded file path to plugin defined constant path.
-	 *
-	 * @since 1.6.10
-	 *
-	 * @param Array $arr An associative array which holds upload path configuration.
-	 *
-	 * @return Array
-	 */
-	public static function style_kits_upload_dir( $arr ) {
-		$folder = ANG_SK_UPLOAD_DIR;
-
-		$arr['path']   = $arr['basedir'] . $folder;
-		$arr['url']    = $arr['baseurl'] . $folder;
-		$arr['subdir'] = $folder;
-
-		return $arr;
 	}
 }
 

--- a/inc/api/class-local.php
+++ b/inc/api/class-local.php
@@ -320,6 +320,10 @@ class Local extends Base {
 			return new WP_Error( 'license_error', __( 'Invalid or expired license provided.', 'ang' ) );
 		}
 
+		global $global_subdirectory_name;
+		$global_subdirectory_name  = 'template-' . $template['site_id'] . '-' . $template['id'] . '-';
+		$global_subdirectory_name .= hash( 'crc32', $global_subdirectory_name );
+
 		// Initiate template import.
 		$obj = new Analog_Importer();
 
@@ -600,6 +604,10 @@ class Local extends Base {
 			return new WP_Error( 'kit_post_error', $kit_id->get_error_message() );
 		}
 
+		global $global_subdirectory_name;
+		$global_subdirectory_name  = 'stylekit-' . $kit['site_id'] . '-' . $kit['id'] . '-';
+		$global_subdirectory_name .= hash( 'crc32', $global_subdirectory_name );
+
 		add_filter( 'upload_dir', array( 'Analog\Utils', 'style_kits_upload_dir' ) );
 		$attachment = Import_Image::get_instance()->import(
 			array(
@@ -700,6 +708,11 @@ class Local extends Base {
 		}
 
 		$raw_data = Remote::get_instance()->get_block_content( $block['id'], $license, $method, $block['siteID'] );
+
+		global $global_subdirectory_name;
+		$global_subdirectory_name  = 'block-' . $block['siteID'] . '-' . $block['id'] . '-';
+		$global_subdirectory_name .= hash( 'crc32', $global_subdirectory_name );
+
 		$importer = new Analog_Importer();
 
 		$data = $importer->get_data(

--- a/inc/api/class-local.php
+++ b/inc/api/class-local.php
@@ -600,14 +600,14 @@ class Local extends Base {
 			return new WP_Error( 'kit_post_error', $kit_id->get_error_message() );
 		}
 
-		add_filter( 'upload_dir', array('Analog\Utils', 'style_kits_upload_dir') );
+		add_filter( 'upload_dir', array( 'Analog\Utils', 'style_kits_upload_dir' ) );
 		$attachment = Import_Image::get_instance()->import(
 			array(
 				'id'  => wp_rand( 000, 999 ),
 				'url' => $kit['image'],
 			)
 		);
-		remove_filter( 'upload_dir', array('Analog\Utils', 'style_kits_upload_dir') );
+		remove_filter( 'upload_dir', array( 'Analog\Utils', 'style_kits_upload_dir' ) );
 
 		update_post_meta( $kit_id, '_thumbnail_id', $attachment['id'] );
 

--- a/inc/api/class-local.php
+++ b/inc/api/class-local.php
@@ -600,12 +600,14 @@ class Local extends Base {
 			return new WP_Error( 'kit_post_error', $kit_id->get_error_message() );
 		}
 
+		add_filter( 'upload_dir', array('Analog\Utils', 'style_kits_upload_dir') );
 		$attachment = Import_Image::get_instance()->import(
 			array(
 				'id'  => wp_rand( 000, 999 ),
 				'url' => $kit['image'],
 			)
 		);
+		remove_filter( 'upload_dir', array('Analog\Utils', 'style_kits_upload_dir') );
 
 		update_post_meta( $kit_id, '_thumbnail_id', $attachment['id'] );
 

--- a/inc/class-analog-importer.php
+++ b/inc/class-analog-importer.php
@@ -60,9 +60,9 @@ class Analog_Importer extends Source_Remote {
 
 		$data['content'] = $this->replace_elements_ids( $data['content'] );
 
-		add_filter( 'upload_dir', array('Analog\Utils', 'style_kits_upload_dir') );
+		add_filter( 'upload_dir', array( 'Analog\Utils', 'style_kits_upload_dir' ) );
 		$data['content'] = $this->process_export_import_content( $data['content'], 'on_import' );
-		remove_filter( 'upload_dir', array('Analog\Utils', 'style_kits_upload_dir') );
+		remove_filter( 'upload_dir', array( 'Analog\Utils', 'style_kits_upload_dir' ) );
 
 		$post_id  = $args['editor_post_id'];
 		$document = Plugin::elementor()->documents->get( $post_id );

--- a/inc/class-analog-importer.php
+++ b/inc/class-analog-importer.php
@@ -59,7 +59,10 @@ class Analog_Importer extends Source_Remote {
 		}
 
 		$data['content'] = $this->replace_elements_ids( $data['content'] );
+
+		add_filter( 'upload_dir', array('Analog\Utils', 'style_kits_upload_dir') );
 		$data['content'] = $this->process_export_import_content( $data['content'], 'on_import' );
+		remove_filter( 'upload_dir', array('Analog\Utils', 'style_kits_upload_dir') );
 
 		$post_id  = $args['editor_post_id'];
 		$document = Plugin::elementor()->documents->get( $post_id );

--- a/inc/class-analog-importer.php
+++ b/inc/class-analog-importer.php
@@ -60,9 +60,9 @@ class Analog_Importer extends Source_Remote {
 
 		$data['content'] = $this->replace_elements_ids( $data['content'] );
 
-		add_filter( 'upload_dir', array( 'Analog\Utils', 'style_kits_upload_dir' ) );
+		add_filter( 'upload_dir', array( Utils::class, 'style_kits_upload_dir' ) );
 		$data['content'] = $this->process_export_import_content( $data['content'], 'on_import' );
-		remove_filter( 'upload_dir', array( 'Analog\Utils', 'style_kits_upload_dir' ) );
+		remove_filter( 'upload_dir', array( Utils::class, 'style_kits_upload_dir' ) );
 
 		$post_id  = $args['editor_post_id'];
 		$document = Plugin::elementor()->documents->get( $post_id );

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "build": "cross-env BABEL_ENV=default NODE_ENV=production webpack",
-    "dev": "cross-env BABEL_ENV=default webpack --mode=development --watch",
+    "dev": "cross-env BABEL_ENV=default webpack --watch",
     "test": "echo \"Error: no test specified\" && exit 1",
     "makepot": "wp i18n make-pot . ./languages/ang.pot --merge=languages/ang-js.pot --skip-js",
     "makepot:php": "npx pot-to-php languages/ang.pot languages/ang-translations.php ang",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "build": "cross-env BABEL_ENV=default NODE_ENV=production webpack",
-    "dev": "cross-env BABEL_ENV=default webpack --watch",
+    "dev": "cross-env BABEL_ENV=default webpack --mode=development --watch",
     "test": "echo \"Error: no test specified\" && exit 1",
     "makepot": "wp i18n make-pot . ./languages/ang.pot --merge=languages/ang-js.pot --skip-js",
     "makepot:php": "npx pot-to-php languages/ang.pot languages/ang-translations.php ang",


### PR DESCRIPTION
Implemented the custom directory feature.
Sub-directories created under: uploads/style_kits
Template directory: template-23-521-03148a9d
Style Kit directory: stylekit-23-39-1408a32a
Block directory: block-5-856-47c7e512

1. When import occurs in code
2. Apply a filter on a hook that fires up when an image is uploaded
3. Read that image attachment, and check for `_elementor_source_image_hash` or `_analog_image_hash`
4. If true, add that post ID to a new options object
5. Remove the filter once we’re finished importing