### PR TITLE
#460 Fixed the issue, notices are now properly rendering beneath the …

### DIFF
--- a/client/Synchronization.js
+++ b/client/Synchronization.js
@@ -8,40 +8,43 @@ const { Button } = wp.components;
 
 const Synchronization = () => {
 	return (
-		<div id="sk-library-heading">
-			<h1>{ __( 'Style Kits Library', 'ang' ) }</h1>
-			<div>
-				<AnalogContext.Consumer>
-					{ context => (
-						<NotificationConsumer>
-							{ ( { add } ) => (
-								<Button isPrimary
-									className={ classNames( 'alignright', {
-										'is-active': context.state.syncing,
-									} ) }
-									onClick={ e => {
-										e.preventDefault();
-										context.forceRefresh()
-											.then( () => add( __( 'Templates library refreshed', 'ang' ) ) )
-											.catch( () => add( __( 'Error refreshing templates library, please try again.', 'ang' ), 'error' ) );
-									} }
-								>
-									{ context.state.syncing ?
-										__( 'Syncing...', 'ang' ) :
-										__( 'Sync Library', 'ang' ) }
-									{ /*<Refresh />*/ }
-								</Button>
-							) }
-						</NotificationConsumer>
+		<>
+			<div id="sk-library-heading">
+				<h1>{ __( 'Style Kits Library', 'ang' ) }</h1>
+				<div>
+					<AnalogContext.Consumer>
+						{ context => (
+							<NotificationConsumer>
+								{ ( { add } ) => (
+									<Button isPrimary
+										className={ classNames( 'alignright', {
+											'is-active': context.state.syncing,
+										} ) }
+										onClick={ e => {
+											e.preventDefault();
+											context.forceRefresh()
+												.then( () => add( __( 'Templates library refreshed', 'ang' ) ) )
+												.catch( () => add( __( 'Error refreshing templates library, please try again.', 'ang' ), 'error' ) );
+										} }
+									>
+										{ context.state.syncing ?
+											__( 'Syncing...', 'ang' ) :
+											__( 'Sync Library', 'ang' ) }
+										{ /*<Refresh />*/ }
+									</Button>
+								) }
+							</NotificationConsumer>
+						) }
+					</AnalogContext.Consumer>
+					{ ! AGWP.is_settings_page && (
+						<Button isSecondary className="close-modal">
+							{ __( 'Close', 'ang' ) } <Close />
+						</Button>
 					) }
-				</AnalogContext.Consumer>
-				{ ! AGWP.is_settings_page && (
-					<Button isSecondary className="close-modal">
-						{ __( 'Close', 'ang' ) } <Close />
-					</Button>
-				) }
+				</div>
 			</div>
-		</div>
+			<hr class="wp-header-end"></hr>
+		</>
 	);
 };
 


### PR DESCRIPTION
Resolves #460 
Fixed the issue, notices are now properly rendering beneath the header, WP by default using JS inject the notices beneath the h1 tag to avoid that need to add hr tag with the wp-header-end class