### PR TITLE
#468 Update class Theme_Style_Kits compatible with El 3.1

### DIFF
--- a/inc/elementor/js/ang-action.js
+++ b/inc/elementor/js/ang-action.js
@@ -494,32 +494,38 @@ jQuery( window ).on( 'elementor:init', function() {
 			jQuery('body').toggleClass( 'dark-mode', elementor.settings.editorPreferences.model.attributes.ui_theme === 'dark' );
 		}
 
-		const globalComponent = $e.components.get('panel/global');
-
-		if ( 'undefined' !== typeof globalComponent && ! globalComponent.hasTab('theme-style-kits') ) {
-			globalComponent.addTab(
-				'theme-style-kits',
-				{
-					title: 'Style Kits',
-					icon: 'eicon-global-settings',
-					helpUrl: 'https://docs.analogwp.com/'
-				},
-				6
-			);
-		}
-
-		const kitMenuItem = elementor.getPanelView('kit_menu').getPages().kit_menu;
-
-		if ( 'undefined' !== typeof kitMenuItem ) {
-			const PanelView = kitMenuItem.view;
-			PanelView.addItem( PanelView.getGroups(), {
-				name: 'theme-style-kits',
-				icon: 'eicon-global-settings',
-				title: 'Style Kits',
-				callback: () => $e.route( 'panel/global/theme-style-kits' ),
-			}, 'theme_style' );
-		}
 	} );
+
+	if ( elementor.helpers.compareVersions( ElementorConfig.version, '3.1.0', '<' ) ) {
+		elementor.once( 'globals:loaded', () => {
+			const globalComponent = $e.components.get('panel/global');
+
+			if ( 'undefined' !== typeof globalComponent && ! globalComponent.hasTab('theme-style-kits') ) {
+				globalComponent.addTab(
+					'theme-style-kits',
+					{
+						title: 'Style Kits',
+						icon: 'eicon-global-settings',
+						helpUrl: 'https://docs.analogwp.com/'
+					},
+					6
+				);
+			}
+
+			const kitMenuItem = elementor.getPanelView('kit_menu').getPages().kit_menu;
+
+			if ( 'undefined' !== typeof kitMenuItem ) {
+				const PanelView = kitMenuItem.view;
+				PanelView.addItem( PanelView.getGroups(), {
+					name: 'theme-style-kits',
+					icon: 'eicon-global-settings',
+					title: 'Style Kits',
+					callback: () => $e.route( 'panel/global/theme-style-kits' ),
+				}, 'theme_style' );
+			}
+		});
+	}
+
 
 	jQuery('#elementor-panel').on('change', '[data-setting="ui_theme"]', function(e) {
 		const value = e.target.value;

--- a/inc/elementor/kit/tabs/Theme_Style_Kits.php
+++ b/inc/elementor/kit/tabs/Theme_Style_Kits.php
@@ -47,6 +47,33 @@ class Theme_Style_Kits extends Tab_Base {
 	}
 
 	/**
+	 * Tab Group.
+	 *
+	 * @return string
+	 */
+	public function get_group() {
+		return 'theme-style';
+	}
+
+	/**
+	 * Tab icon.
+	 *
+	 * @return string
+	 */
+	public function get_icon() {
+		return 'eicon-global-settings';
+	}
+
+	/**
+	 * Tab help URL.
+	 *
+	 * @return string
+	 */
+	public function get_help_url() {
+		return 'https://docs.analogwp.com/';
+	}
+
+	/**
 	 * Tab controls.
 	 *
 	 * Tab controls are hooked mostly on `elementor/element/kit/section_buttons/after_section_end`.
@@ -55,3 +82,13 @@ class Theme_Style_Kits extends Tab_Base {
 }
 
 new Theme_Style_Kits( Kit::class );
+
+/**
+ * Fires on tabs registering.
+ */
+add_action(
+	'elementor/kit/register_tabs',
+	function( $kit ) {
+		$kit->register_tab( 'theme-style-kits', Theme_Style_Kits::class );
+	}
+);


### PR DESCRIPTION
resolves #468 

Update  add tab JS logic to work only for lesser than El 3.1 version 
Hook the add tab block to Elementor channel event globals:loaded