### PR TITLE
Release v1.9.2

### DIFF
--- a/analogwp-templates.php
+++ b/analogwp-templates.php
@@ -10,7 +10,7 @@
  * Plugin Name: Style Kits for Elementor
  * Plugin URI:  https://analogwp.com/
  * Description: Style Kits extends the Elementor theme styles editor with more global styling options. Boost your design workflow in Elementor with intuitive global controls and theme style presets.
- * Version:     1.9.1
+ * Version:     1.9.2
  * Author:      AnalogWP
  * Author URI:  https://analogwp.com/
  * License:     GPL2
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'ANG_ELEMENTOR_MINIMUM', '3.5.0' );
 define( 'ANG_PHP_MINIMUM', '5.6.0' );
 define( 'ANG_WP_MINIMUM', '5.2' );
-define( 'ANG_VERSION', '1.9.1' );
+define( 'ANG_VERSION', '1.9.2' );
 define( 'ANG_PLUGIN_FILE', __FILE__ );
 define( 'ANG_PLUGIN_URL', plugin_dir_url( ANG_PLUGIN_FILE ) );
 define( 'ANG_PLUGIN_DIR', plugin_dir_path( ANG_PLUGIN_FILE ) );

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -568,7 +568,7 @@ class Typography extends Module {
 		$element->add_control(
 			'ang_container_padding_reset',
 			array(
-				'label' => __( 'Reset presets to default', 'ang' ),
+				'label' => __( 'Reset labels and values to default', 'ang' ),
 				'type'  => 'button',
 				'text'  => __( 'Reset', 'ang' ),
 				'event' => 'analog:resetContainerPadding',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analogwp-templates",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Handfully crafted Elementor templates packs.",
   "main": "/client/index.js",
   "private": true,

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: analogwp, mauryaratan
 Requires at least: 5.2
 Requires PHP: 5.6
 Tested up to: 6.0
-Stable tag: 1.9.1
+Stable tag: 1.9.2
 Tags: elementor, templates, landing page, template kit, design, website builder, page builder
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -105,6 +105,15 @@ Our dedicated support team has your back. Please reach out via our website at ht
 19. "Tools" panel inside Elementor style tab.
 
 == Changelog ==
+
+= 1.9.2 - June 24, 2022 =
+* New: Added Kit sizes helper links at Heading & Button widgets
+* New: Added default values for Container spacing presets
+* Improvements: Show Style Kit colors & fonts links at Contextual popup with respect to active experiments
+* Improvements: Reset actions now directly take you to their respected sections
+* Improvements: Remove section titles & revise labels from Style Kit fonts
+* Improvements: Remove sction titls from Style Kit colors
+* Fix: Contextual links now directly take you their respected sections
 
 = 1.9.1 - June 18, 2022 =
 * New: Add "Edit Style Kit Fonts" link to the context menu

--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,7 @@ Our dedicated support team has your back. Please reach out via our website at ht
 * Improvements: Reset actions now directly take you to their respected sections
 * Improvements: Remove section titles & revise labels from Style Kit fonts
 * Improvements: Remove sction titls from Style Kit colors
+* Fix: Style Kit font presets reset button not working
 * Fix: Contextual links now directly take you their respected sections
 
 = 1.9.1 - June 18, 2022 =

--- a/readme.txt
+++ b/readme.txt
@@ -112,9 +112,9 @@ Our dedicated support team has your back. Please reach out via our website at ht
 * Improvements: Show Style Kit colors & fonts links at Contextual popup with respect to active experiments
 * Improvements: Reset actions now directly take you to their respected sections
 * Improvements: Remove section titles & revise labels from Style Kit fonts
-* Improvements: Remove sction titls from Style Kit colors
+* Improvements: Remove section titles from Style Kit colors
 * Fix: Style Kit font presets reset button not working
-* Fix: Contextual links now directly take you their respected sections
+* Fix: Contextual links now directly take you to their respected sections
 
 = 1.9.1 - June 18, 2022 =
 * New: Add "Edit Style Kit Fonts" link to the context menu


### PR DESCRIPTION
* New: Added Kit sizes helper links at Heading & Button widgets
* New: Added default values for Container spacing presets
* Improvements: Show Style Kit colors & fonts links at Contextual popup with respect to active experiments
* Improvements: Reset actions now directly take you to their respected sections
* Improvements: Remove section titles & revise labels from Style Kit fonts
* Improvements: Remove section titles from Style Kit colors
* Fix: Style Kit font presets reset button not working
* Fix: Contextual links now directly take you to their respected sections