### PR TITLE
Tabbed layout for Global Colors and Fonts

### DIFF
--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -41,7 +41,13 @@ final class Promotions extends Base {
 		$global_colors_experiment = Options::get_instance()->get( 'global_colors_experiment' );
 
 		if ( 'active' === $global_colors_experiment ) {
-			add_action( 'analog_global_colors_tab_end', array( $this, 'add_additional_tabs_promo' ), 170, 2 );
+			add_action( 'analog_global_colors_tab_end', array( $this, 'add_additional_color_tabs_promo' ), 170, 2 );
+		}
+
+		$global_fonts_experiment = Options::get_instance()->get( 'global_fonts_experiment' );
+
+		if ( 'active' === $global_fonts_experiment ) {
+			add_action( 'analog_global_fonts_tab_end', array( $this, 'add_additional_font_tabs_promo' ), 170, 2 );
 		}
 	}
 
@@ -336,7 +342,6 @@ final class Promotions extends Base {
 		);
 	}
 
-
 	/**
 	 * Modify original "Style Kit Colors" tabs.
 	 *
@@ -345,7 +350,7 @@ final class Promotions extends Base {
 	 * @param Controls_Stack $element Elementor element.
 	 * @param Repeater       $repeater Elementor repeater element.
 	 */
-	public function add_additional_tabs_promo( Controls_Stack $element, Repeater $repeater ) {
+	public function add_additional_color_tabs_promo( Controls_Stack $element, Repeater $repeater ) {
 		$element->start_controls_tab(
 			'ang_tab_global_colors_secondary',
 			array( 'label' => __( '17-32', 'ang' ) )
@@ -358,7 +363,7 @@ final class Promotions extends Base {
 				'raw'  => $this->get_updated_teaser_template(
 					array(
 						'messages' => array(
-							__( 'Extend your color system with more variables, plus many more features with Style Kist Pro.', 'ang' ),
+							__( 'Extend your color system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
 						),
 						'link'     => array( 'utm_source' => 'ang-global-colors' ),
 					)
@@ -380,9 +385,63 @@ final class Promotions extends Base {
 				'raw'  => $this->get_updated_teaser_template(
 					array(
 						'messages' => array(
-							__( 'Extend your color system with more variables, plus many more features with Style Kist Pro.', 'ang' ),
+							__( 'Extend your color system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
 						),
 						'link'     => array( 'utm_source' => 'ang-global-colors' ),
+					)
+				),
+			)
+		);
+
+		$element->end_controls_tab();
+	}
+
+	/**
+	 * Modify original "Style Kit Fonts" tabs.
+	 *
+	 * @hook analog_global_fonts_tab_end
+	 *
+	 * @param Controls_Stack $element Elementor element.
+	 * @param Repeater       $repeater Elementor repeater element.
+	 */
+	public function add_additional_font_tabs_promo( Controls_Stack $element, Repeater $repeater ) {
+		$element->start_controls_tab(
+			'ang_tab_global_fonts_secondary',
+			array( 'label' => __( '17-32', 'ang' ) )
+		);
+
+		$element->add_control(
+			'ang_global_fonts_secondary_tab_promo',
+			array(
+				'type' => Controls_Manager::RAW_HTML,
+				'raw'  => $this->get_updated_teaser_template(
+					array(
+						'messages' => array(
+							__( 'Extend your typography system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
+						),
+						'link'     => array( 'utm_source' => 'ang-global-fonts' ),
+					)
+				),
+			)
+		);
+
+		$element->end_controls_tab();
+
+		$element->start_controls_tab(
+			'ang_tab_global_fonts_tertiary',
+			array( 'label' => __( '33-64', 'ang' ) )
+		);
+
+		$element->add_control(
+			'ang_global_fonts_tertiary_tab_promo',
+			array(
+				'type' => Controls_Manager::RAW_HTML,
+				'raw'  => $this->get_updated_teaser_template(
+					array(
+						'messages' => array(
+							__( 'Extend your typography system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
+						),
+						'link'     => array( 'utm_source' => 'ang-global-fonts' ),
 					)
 				),
 			)

--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -37,6 +37,12 @@ final class Promotions extends Base {
 		if ( 'active' === $container_spacing_experiment ) {
 			add_action( 'analog_container_spacing_section_end', array( $this, 'add_container_custom_spacing_promo' ), 170, 2 );
 		}
+
+		$global_colors_experiment = Options::get_instance()->get( 'global_colors_experiment' );
+
+		if ( 'active' === $global_colors_experiment ) {
+			add_action( 'analog_global_colors_tab_end', array( $this, 'add_additional_tabs_promo' ), 170, 2 );
+		}
 	}
 
 	/**
@@ -190,6 +196,50 @@ final class Promotions extends Base {
 	}
 
 	/**
+	 * Get promotional teaser template (Updated).
+	 *
+	 * @since 1.9.3
+	 * @param array $texts Text arguments.
+	 *
+	 * @return false|string
+	 */
+	public function get_updated_teaser_template( $texts ) {
+		ob_start();
+		?>
+		<div class="elementor-nerd-box" style="padding: 0; display: flex; align-items: baseline; gap: 10px; text-align: left;">
+			<div style="align-self: center;">
+
+				<?php
+				if ( $texts['title'] ) :
+					?>
+					<div class="elementor-nerd-box-title"><?php echo $texts['title']; // @codingStandardsIgnoreLine ?></div>
+					<?php
+				endif;
+				foreach ( $texts['messages'] as $message ) {
+					?>
+					<div class="elementor-nerd-box-message"><?php echo $message; // @codingStandardsIgnoreLine ?></div>
+					<?php
+				}
+
+				if ( $texts['link'] ) {
+					?>
+					<a
+							class="elementor-nerd-box-link elementor-button elementor-button-default elementor-button-go-pro"
+							href="<?php echo esc_url( Utils::get_pro_link( $texts['link'] ) ); ?>"
+							style="background-color:var(--ang-accent)"
+							target="_blank">
+						<?php esc_html_e( 'Learn More', 'ang' ); ?>
+					</a>
+				<?php } ?>
+			</div>
+			<img class="elementor-nerd-box-icon" style="width:45px;margin-right:0;" alt="Style Kits for Elementor" src="<?php echo esc_url( ANG_PLUGIN_URL . 'assets/img/analog.svg' ); ?>" />
+		</div>
+		<?php
+
+		return ob_get_clean();
+	}
+
+	/**
 	 * Modify original "Background Color Classes" controls.
 	 *
 	 * @hook analog_background_colors_tab_end
@@ -284,6 +334,61 @@ final class Promotions extends Base {
 				),
 			)
 		);
+	}
+
+
+	/**
+	 * Modify original "Style Kit Colors" tabs.
+	 *
+	 * @hook analog_global_colors_tab_end
+	 *
+	 * @param Controls_Stack $element Elementor element.
+	 * @param Repeater       $repeater Elementor repeater element.
+	 */
+	public function add_additional_tabs_promo( Controls_Stack $element, Repeater $repeater ) {
+		$element->start_controls_tab(
+			'ang_tab_global_colors_secondary',
+			array( 'label' => __( '17-32', 'ang' ) )
+		);
+
+		$element->add_control(
+			'ang_global_colors_secondary_tab_promo',
+			array(
+				'type' => Controls_Manager::RAW_HTML,
+				'raw'  => $this->get_updated_teaser_template(
+					array(
+						'messages' => array(
+							__( 'Extend your color system with more variables, plus many more features with Style Kist Pro.', 'ang' ),
+						),
+						'link'     => array( 'utm_source' => 'ang-global-colors' ),
+					)
+				),
+			)
+		);
+
+		$element->end_controls_tab();
+
+		$element->start_controls_tab(
+			'ang_tab_global_colors_tertiary',
+			array( 'label' => __( '33-64', 'ang' ) )
+		);
+
+		$element->add_control(
+			'ang_global_colors_tertiary_tab_promo',
+			array(
+				'type' => Controls_Manager::RAW_HTML,
+				'raw'  => $this->get_updated_teaser_template(
+					array(
+						'messages' => array(
+							__( 'Extend your color system with more variables, plus many more features with Style Kist Pro.', 'ang' ),
+						),
+						'link'     => array( 'utm_source' => 'ang-global-colors' ),
+					)
+				),
+			)
+		);
+
+		$element->end_controls_tab();
 	}
 }
 

--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -375,7 +375,7 @@ final class Promotions extends Base {
 
 		$element->start_controls_tab(
 			'ang_tab_global_colors_tertiary',
-			array( 'label' => __( '33-64', 'ang' ) )
+			array( 'label' => __( '33-48', 'ang' ) )
 		);
 
 		$element->add_control(
@@ -429,7 +429,7 @@ final class Promotions extends Base {
 
 		$element->start_controls_tab(
 			'ang_tab_global_fonts_tertiary',
-			array( 'label' => __( '33-64', 'ang' ) )
+			array( 'label' => __( '33-48', 'ang' ) )
 		);
 
 		$element->add_control(

--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -368,6 +368,7 @@ final class Promotions extends Base {
 						'link'     => array( 'utm_source' => 'ang-global-colors' ),
 					)
 				),
+				'separator'    => 'before',
 			)
 		);
 
@@ -381,8 +382,8 @@ final class Promotions extends Base {
 		$element->add_control(
 			'ang_global_colors_tertiary_tab_promo',
 			array(
-				'type' => Controls_Manager::RAW_HTML,
-				'raw'  => $this->get_updated_teaser_template(
+				'type'      => Controls_Manager::RAW_HTML,
+				'raw'       => $this->get_updated_teaser_template(
 					array(
 						'messages' => array(
 							__( 'Extend your color system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
@@ -390,6 +391,7 @@ final class Promotions extends Base {
 						'link'     => array( 'utm_source' => 'ang-global-colors' ),
 					)
 				),
+				'separator' => 'before',
 			)
 		);
 

--- a/inc/elementor/class-colors.php
+++ b/inc/elementor/class-colors.php
@@ -390,6 +390,13 @@ class Colors extends Module {
 			)
 		);
 
+		$element->start_controls_tabs( 'ang_global_colors_section_tabs' );
+
+		$element->start_controls_tab(
+			'ang_tab_global_colors_primary',
+			array( 'label' => __( '1-16', 'ang' ) )
+		);
+
 		$repeater = new Repeater();
 
 		$repeater->add_control(
@@ -584,6 +591,12 @@ class Colors extends Module {
 				'event' => 'analog:resetGlobalColors',
 			)
 		);
+
+		$element->end_controls_tab();
+
+		do_action( 'analog_global_colors_tab_end', $element, $repeater );
+
+		$element->end_controls_tabs();
 
 		$element->end_controls_section();
 	}

--- a/inc/elementor/class-colors.php
+++ b/inc/elementor/class-colors.php
@@ -390,7 +390,12 @@ class Colors extends Module {
 			)
 		);
 
-		$element->start_controls_tabs( 'ang_global_colors_section_tabs' );
+		$element->start_controls_tabs(
+			'ang_global_colors_section_tabs',
+			array(
+				'separator' => 'before',
+			)
+		);
 
 		$element->start_controls_tab(
 			'ang_tab_global_colors_primary',
@@ -538,7 +543,7 @@ class Colors extends Module {
 					'remove' => false,
 					'sort'   => false,
 				),
-				'separator'    => 'after',
+				'separator'    => 'before',
 			)
 		);
 
@@ -577,7 +582,7 @@ class Colors extends Module {
 					'remove' => false,
 					'sort'   => false,
 				),
-				'separator'    => 'after',
+				'separator'    => '',
 			)
 		);
 

--- a/inc/elementor/class-colors.php
+++ b/inc/elementor/class-colors.php
@@ -503,7 +503,6 @@ class Colors extends Module {
 			)
 		);
 
-
 		// Text Colors.
 		$default_type_colors = array(
 			array(
@@ -582,6 +581,12 @@ class Colors extends Module {
 			)
 		);
 
+		$element->end_controls_tab();
+
+		do_action( 'analog_global_colors_tab_end', $element, $repeater );
+
+		$element->end_controls_tabs();
+
 		$element->add_control(
 			'ang_global_reset_colors',
 			array(
@@ -591,12 +596,6 @@ class Colors extends Module {
 				'event' => 'analog:resetGlobalColors',
 			)
 		);
-
-		$element->end_controls_tab();
-
-		do_action( 'analog_global_colors_tab_end', $element, $repeater );
-
-		$element->end_controls_tabs();
 
 		$element->end_controls_section();
 	}

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -1550,7 +1550,12 @@ class Typography extends Module {
 			)
 		);
 
-		$element->start_controls_tabs( 'ang_global_fonts_section_tabs' );
+		$element->start_controls_tabs(
+			'ang_global_fonts_section_tabs',
+			array(
+				'separator' => 'before',
+			)
+		);
 
 		$element->start_controls_tab(
 			'ang_tab_global_fonts_primary',
@@ -1672,7 +1677,6 @@ class Typography extends Module {
 					'remove' => false,
 					'sort'   => false,
 				),
-				'separator'    => 'after',
 			)
 		);
 
@@ -1722,7 +1726,7 @@ class Typography extends Module {
 					'remove' => false,
 					'sort'   => false,
 				),
-				'separator'    => 'after',
+				'separator'    => 'before',
 			)
 		);
 

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -1550,6 +1550,13 @@ class Typography extends Module {
 			)
 		);
 
+		$element->start_controls_tabs( 'ang_global_fonts_section_tabs' );
+
+		$element->start_controls_tab(
+			'ang_tab_global_fonts_primary',
+			array( 'label' => __( '1-16', 'ang' ) )
+		);
+
 		$repeater = new Repeater();
 
 		$repeater->add_control(
@@ -1718,6 +1725,12 @@ class Typography extends Module {
 				'separator'    => 'after',
 			)
 		);
+
+		$element->end_controls_tab();
+
+		do_action( 'analog_global_fonts_tab_end', $element, $repeater );
+
+		$element->end_controls_tabs();
 
 		$element->add_control(
 			'ang_global_reset_fonts',

--- a/inc/elementor/globals/class-colors.php
+++ b/inc/elementor/globals/class-colors.php
@@ -49,6 +49,10 @@ class Colors extends Base {
 			'ang_global_accent_colors',
 			'ang_global_text_colors',
 			'ang_global_extra_colors',
+			'ang_global_secondary_part_one_colors',
+			'ang_global_secondary_part_two_colors',
+			'ang_global_tertiary_part_one_colors',
+			'ang_global_tertiary_part_two_colors',
 		);
 
 		foreach ( $color_keys as $color_key ) {

--- a/inc/elementor/globals/class-colors.php
+++ b/inc/elementor/globals/class-colors.php
@@ -69,8 +69,8 @@ class Colors extends Base {
 			$id            = $item['_id'];
 			$result[ $id ] = array(
 				'id'    => $id,
-				'title' => $item['title'],
-				'value' => $item['color'],
+				'title' => $item['title'] ?? '',
+				'value' => $item['color'] ?? '',
 			);
 		}
 

--- a/inc/elementor/globals/class-typography.php
+++ b/inc/elementor/globals/class-typography.php
@@ -54,6 +54,10 @@ class Typography extends Base {
 		$font_keys = array(
 			'ang_global_title_fonts',
 			'ang_global_text_fonts',
+			'ang_global_secondary_part_one_fonts',
+			'ang_global_secondary_part_two_fonts',
+			'ang_global_tertiary_part_one_fonts',
+			'ang_global_tertiary_part_two_fonts',
 		);
 
 		foreach ( $font_keys as $font_key ) {

--- a/inc/elementor/globals/class-typography.php
+++ b/inc/elementor/globals/class-typography.php
@@ -91,7 +91,7 @@ class Typography extends Base {
 			$id = $item['_id'];
 
 			$result[ $id ] = array(
-				'title' => $item['title'],
+				'title' => $item['title'] ?? '',
 				'id'    => $id,
 			);
 

--- a/inc/elementor/js/ang-action.js
+++ b/inc/elementor/js/ang-action.js
@@ -541,6 +541,10 @@ jQuery( window ).on( 'elementor/init', function() {
 				'ang_global_accent_colors',
 				'ang_global_text_colors',
 				'ang_global_extra_colors',
+				'ang_global_secondary_part_one_colors',
+				'ang_global_secondary_part_two_colors',
+				'ang_global_tertiary_part_one_colors',
+				'ang_global_tertiary_part_two_colors',
 			];
 
 		let defaultValues = {};
@@ -578,6 +582,10 @@ jQuery( window ).on( 'elementor/init', function() {
 		const ang_global_fonts = [
 			'ang_global_title_fonts',
 			'ang_global_text_fonts',
+			'ang_global_secondary_part_one_fonts',
+			'ang_global_secondary_part_two_fonts',
+			'ang_global_tertiary_part_one_fonts',
+			'ang_global_tertiary_part_two_fonts',
 		];
 
 		let defaultValues = {};


### PR DESCRIPTION
Fixes #531 

### How to test
1. Make sure to activate Style Kit Color Palette & Fonts option at Style Kits >> Settings and then Experiments.
2. Go to Elementor editor screen, open Site settings.
3. From Site settings, go to Global Colors and then Style Kit Colors similarly for fonts look into Global Fonts.
4. Add/update a few options and select them at widget color/typo global popup.
5. Test Reset button, it should reset options to their default state.