### PR TITLE
Move shadow controls

### DIFF
--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -41,7 +41,13 @@ final class Promotions extends Base {
 		$global_colors_experiment = Options::get_instance()->get( 'global_colors_experiment' );
 
 		if ( 'active' === $global_colors_experiment ) {
-			add_action( 'analog_global_colors_tab_end', array( $this, 'add_additional_tabs_promo' ), 170, 2 );
+			add_action( 'analog_global_colors_tab_end', array( $this, 'add_additional_color_tabs_promo' ), 170, 2 );
+		}
+
+		$global_fonts_experiment = Options::get_instance()->get( 'global_fonts_experiment' );
+
+		if ( 'active' === $global_fonts_experiment ) {
+			add_action( 'analog_global_fonts_tab_end', array( $this, 'add_additional_font_tabs_promo' ), 170, 2 );
 		}
 	}
 
@@ -336,7 +342,6 @@ final class Promotions extends Base {
 		);
 	}
 
-
 	/**
 	 * Modify original "Style Kit Colors" tabs.
 	 *
@@ -345,7 +350,7 @@ final class Promotions extends Base {
 	 * @param Controls_Stack $element Elementor element.
 	 * @param Repeater       $repeater Elementor repeater element.
 	 */
-	public function add_additional_tabs_promo( Controls_Stack $element, Repeater $repeater ) {
+	public function add_additional_color_tabs_promo( Controls_Stack $element, Repeater $repeater ) {
 		$element->start_controls_tab(
 			'ang_tab_global_colors_secondary',
 			array( 'label' => __( '17-32', 'ang' ) )
@@ -358,7 +363,7 @@ final class Promotions extends Base {
 				'raw'  => $this->get_updated_teaser_template(
 					array(
 						'messages' => array(
-							__( 'Extend your color system with more variables, plus many more features with Style Kist Pro.', 'ang' ),
+							__( 'Extend your color system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
 						),
 						'link'     => array( 'utm_source' => 'ang-global-colors' ),
 					)
@@ -380,9 +385,63 @@ final class Promotions extends Base {
 				'raw'  => $this->get_updated_teaser_template(
 					array(
 						'messages' => array(
-							__( 'Extend your color system with more variables, plus many more features with Style Kist Pro.', 'ang' ),
+							__( 'Extend your color system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
 						),
 						'link'     => array( 'utm_source' => 'ang-global-colors' ),
+					)
+				),
+			)
+		);
+
+		$element->end_controls_tab();
+	}
+
+	/**
+	 * Modify original "Style Kit Fonts" tabs.
+	 *
+	 * @hook analog_global_fonts_tab_end
+	 *
+	 * @param Controls_Stack $element Elementor element.
+	 * @param Repeater       $repeater Elementor repeater element.
+	 */
+	public function add_additional_font_tabs_promo( Controls_Stack $element, Repeater $repeater ) {
+		$element->start_controls_tab(
+			'ang_tab_global_fonts_secondary',
+			array( 'label' => __( '17-32', 'ang' ) )
+		);
+
+		$element->add_control(
+			'ang_global_fonts_secondary_tab_promo',
+			array(
+				'type' => Controls_Manager::RAW_HTML,
+				'raw'  => $this->get_updated_teaser_template(
+					array(
+						'messages' => array(
+							__( 'Extend your typography system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
+						),
+						'link'     => array( 'utm_source' => 'ang-global-fonts' ),
+					)
+				),
+			)
+		);
+
+		$element->end_controls_tab();
+
+		$element->start_controls_tab(
+			'ang_tab_global_fonts_tertiary',
+			array( 'label' => __( '33-64', 'ang' ) )
+		);
+
+		$element->add_control(
+			'ang_global_fonts_tertiary_tab_promo',
+			array(
+				'type' => Controls_Manager::RAW_HTML,
+				'raw'  => $this->get_updated_teaser_template(
+					array(
+						'messages' => array(
+							__( 'Extend your typography system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
+						),
+						'link'     => array( 'utm_source' => 'ang-global-fonts' ),
 					)
 				),
 			)

--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -37,6 +37,12 @@ final class Promotions extends Base {
 		if ( 'active' === $container_spacing_experiment ) {
 			add_action( 'analog_container_spacing_section_end', array( $this, 'add_container_custom_spacing_promo' ), 170, 2 );
 		}
+
+		$global_colors_experiment = Options::get_instance()->get( 'global_colors_experiment' );
+
+		if ( 'active' === $global_colors_experiment ) {
+			add_action( 'analog_global_colors_tab_end', array( $this, 'add_additional_tabs_promo' ), 170, 2 );
+		}
 	}
 
 	/**
@@ -190,6 +196,50 @@ final class Promotions extends Base {
 	}
 
 	/**
+	 * Get promotional teaser template (Updated).
+	 *
+	 * @since 1.9.3
+	 * @param array $texts Text arguments.
+	 *
+	 * @return false|string
+	 */
+	public function get_updated_teaser_template( $texts ) {
+		ob_start();
+		?>
+		<div class="elementor-nerd-box" style="padding: 0; display: flex; align-items: baseline; gap: 10px; text-align: left;">
+			<div style="align-self: center;">
+
+				<?php
+				if ( $texts['title'] ) :
+					?>
+					<div class="elementor-nerd-box-title"><?php echo $texts['title']; // @codingStandardsIgnoreLine ?></div>
+					<?php
+				endif;
+				foreach ( $texts['messages'] as $message ) {
+					?>
+					<div class="elementor-nerd-box-message"><?php echo $message; // @codingStandardsIgnoreLine ?></div>
+					<?php
+				}
+
+				if ( $texts['link'] ) {
+					?>
+					<a
+							class="elementor-nerd-box-link elementor-button elementor-button-default elementor-button-go-pro"
+							href="<?php echo esc_url( Utils::get_pro_link( $texts['link'] ) ); ?>"
+							style="background-color:var(--ang-accent)"
+							target="_blank">
+						<?php esc_html_e( 'Learn More', 'ang' ); ?>
+					</a>
+				<?php } ?>
+			</div>
+			<img class="elementor-nerd-box-icon" style="width:45px;margin-right:0;" alt="Style Kits for Elementor" src="<?php echo esc_url( ANG_PLUGIN_URL . 'assets/img/analog.svg' ); ?>" />
+		</div>
+		<?php
+
+		return ob_get_clean();
+	}
+
+	/**
 	 * Modify original "Background Color Classes" controls.
 	 *
 	 * @hook analog_background_colors_tab_end
@@ -284,6 +334,61 @@ final class Promotions extends Base {
 				),
 			)
 		);
+	}
+
+
+	/**
+	 * Modify original "Style Kit Colors" tabs.
+	 *
+	 * @hook analog_global_colors_tab_end
+	 *
+	 * @param Controls_Stack $element Elementor element.
+	 * @param Repeater       $repeater Elementor repeater element.
+	 */
+	public function add_additional_tabs_promo( Controls_Stack $element, Repeater $repeater ) {
+		$element->start_controls_tab(
+			'ang_tab_global_colors_secondary',
+			array( 'label' => __( '17-32', 'ang' ) )
+		);
+
+		$element->add_control(
+			'ang_global_colors_secondary_tab_promo',
+			array(
+				'type' => Controls_Manager::RAW_HTML,
+				'raw'  => $this->get_updated_teaser_template(
+					array(
+						'messages' => array(
+							__( 'Extend your color system with more variables, plus many more features with Style Kist Pro.', 'ang' ),
+						),
+						'link'     => array( 'utm_source' => 'ang-global-colors' ),
+					)
+				),
+			)
+		);
+
+		$element->end_controls_tab();
+
+		$element->start_controls_tab(
+			'ang_tab_global_colors_tertiary',
+			array( 'label' => __( '33-64', 'ang' ) )
+		);
+
+		$element->add_control(
+			'ang_global_colors_tertiary_tab_promo',
+			array(
+				'type' => Controls_Manager::RAW_HTML,
+				'raw'  => $this->get_updated_teaser_template(
+					array(
+						'messages' => array(
+							__( 'Extend your color system with more variables, plus many more features with Style Kist Pro.', 'ang' ),
+						),
+						'link'     => array( 'utm_source' => 'ang-global-colors' ),
+					)
+				),
+			)
+		);
+
+		$element->end_controls_tab();
 	}
 }
 

--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -486,7 +486,7 @@ final class Promotions extends Base {
 
 		$element->start_controls_tab(
 			'ang_tab_box_shadows_tertiary',
-			array( 'label' => __( '17-32', 'ang' ) )
+			array( 'label' => __( '17-24', 'ang' ) )
 		);
 
 		$element->add_control(

--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -375,7 +375,7 @@ final class Promotions extends Base {
 
 		$element->start_controls_tab(
 			'ang_tab_global_colors_tertiary',
-			array( 'label' => __( '33-64', 'ang' ) )
+			array( 'label' => __( '33-48', 'ang' ) )
 		);
 
 		$element->add_control(
@@ -429,7 +429,7 @@ final class Promotions extends Base {
 
 		$element->start_controls_tab(
 			'ang_tab_global_fonts_tertiary',
-			array( 'label' => __( '33-64', 'ang' ) )
+			array( 'label' => __( '33-48', 'ang' ) )
 		);
 
 		$element->add_control(

--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -28,7 +28,6 @@ final class Promotions extends Base {
 	public function __construct() {
 		add_action( 'elementor/element/after_section_end', array( $this, 'register_layout_tools' ), 250, 2 );
 		add_action( 'elementor/element/kit/section_buttons/after_section_end', array( $this, 'register_form_controls' ), 45, 2 );
-		add_action( 'elementor/element/kit/section_buttons/after_section_end', array( $this, 'register_shadow_controls' ), 47, 2 );
 
 		add_action( 'analog_background_colors_tab_end', array( $this, 'add_background_color_accent_promo' ), 170, 1 );
 
@@ -49,6 +48,8 @@ final class Promotions extends Base {
 		if ( 'active' === $global_fonts_experiment ) {
 			add_action( 'analog_global_fonts_tab_end', array( $this, 'add_additional_font_tabs_promo' ), 170, 2 );
 		}
+
+		add_action( 'analog_box_shadows_tab_end', array( $this, 'add_additional_shadow_tabs_promo' ), 170, 2 );
 	}
 
 	/**
@@ -444,6 +445,60 @@ final class Promotions extends Base {
 							__( 'Extend your typography system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
 						),
 						'link'     => array( 'utm_source' => 'ang-global-fonts' ),
+					)
+				),
+			)
+		);
+
+		$element->end_controls_tab();
+	}
+
+	/**
+	 * Modify original "Style Kit Shadows" tabs.
+	 *
+	 * @hook analog_box_shadows_tab_end
+	 *
+	 * @param Controls_Stack $element Elementor element.
+	 * @param Repeater       $repeater Elementor repeater element.
+	 */
+	public function add_additional_shadow_tabs_promo( Controls_Stack $element, Repeater $repeater ) {
+		$element->start_controls_tab(
+			'ang_tab_box_shadows_secondary',
+			array( 'label' => __( '8-16', 'ang' ) )
+		);
+
+		$element->add_control(
+			'ang_box_shadows_secondary_tab_promo',
+			array(
+				'type' => Controls_Manager::RAW_HTML,
+				'raw'  => $this->get_updated_teaser_template(
+					array(
+						'messages' => array(
+							__( 'Extend your shadows system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
+						),
+						'link'     => array( 'utm_source' => 'ang-box-shadows' ),
+					)
+				),
+			)
+		);
+
+		$element->end_controls_tab();
+
+		$element->start_controls_tab(
+			'ang_tab_box_shadows_tertiary',
+			array( 'label' => __( '17-32', 'ang' ) )
+		);
+
+		$element->add_control(
+			'ang_box_shadows_tertiary_tab_promo',
+			array(
+				'type' => Controls_Manager::RAW_HTML,
+				'raw'  => $this->get_updated_teaser_template(
+					array(
+						'messages' => array(
+							__( 'Extend your shadows system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
+						),
+						'link'     => array( 'utm_source' => 'ang-box-shadows' ),
 					)
 				),
 			)

--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -368,6 +368,7 @@ final class Promotions extends Base {
 						'link'     => array( 'utm_source' => 'ang-global-colors' ),
 					)
 				),
+				'separator'    => 'before',
 			)
 		);
 
@@ -381,8 +382,8 @@ final class Promotions extends Base {
 		$element->add_control(
 			'ang_global_colors_tertiary_tab_promo',
 			array(
-				'type' => Controls_Manager::RAW_HTML,
-				'raw'  => $this->get_updated_teaser_template(
+				'type'      => Controls_Manager::RAW_HTML,
+				'raw'       => $this->get_updated_teaser_template(
 					array(
 						'messages' => array(
 							__( 'Extend your color system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
@@ -390,6 +391,7 @@ final class Promotions extends Base {
 						'link'     => array( 'utm_source' => 'ang-global-colors' ),
 					)
 				),
+				'separator' => 'before',
 			)
 		);
 

--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -464,7 +464,7 @@ final class Promotions extends Base {
 	public function add_additional_shadow_tabs_promo( Controls_Stack $element, Repeater $repeater ) {
 		$element->start_controls_tab(
 			'ang_tab_box_shadows_secondary',
-			array( 'label' => __( '8-16', 'ang' ) )
+			array( 'label' => __( '9-16', 'ang' ) )
 		);
 
 		$element->add_control(

--- a/inc/elementor/class-ang-action.php
+++ b/inc/elementor/class-ang-action.php
@@ -136,6 +136,7 @@ class ANG_Action extends Base_Data_Control {
 					'resetGlobalColorsMessage'     => __( 'This will revert the color palette and the color labels to their defaults. You can undo this action from the revisions tab.', 'ang' ),
 					'resetGlobalFontsMessage'      => __( 'This will revert the global font labels & values to their defaults. You can undo this action from the revisions tab.', 'ang' ),
 					'resetContainerPaddingMessage' => __( 'This will revert the container preset labels & values to their defaults. You can undo this action from the revisions tab.', 'ang' ),
+					'resetShadowsDesc'             => __( 'This will revert the box shadow presets to their defaults. You can undo this action from the revisions tab.', 'ang' ),
 				),
 				'skPanelsAllowed' => $sk_panels_allowed,
 			)

--- a/inc/elementor/class-colors.php
+++ b/inc/elementor/class-colors.php
@@ -390,6 +390,13 @@ class Colors extends Module {
 			)
 		);
 
+		$element->start_controls_tabs( 'ang_global_colors_section_tabs' );
+
+		$element->start_controls_tab(
+			'ang_tab_global_colors_primary',
+			array( 'label' => __( '1-16', 'ang' ) )
+		);
+
 		$repeater = new Repeater();
 
 		$repeater->add_control(
@@ -584,6 +591,12 @@ class Colors extends Module {
 				'event' => 'analog:resetGlobalColors',
 			)
 		);
+
+		$element->end_controls_tab();
+
+		do_action( 'analog_global_colors_tab_end', $element, $repeater );
+
+		$element->end_controls_tabs();
 
 		$element->end_controls_section();
 	}

--- a/inc/elementor/class-colors.php
+++ b/inc/elementor/class-colors.php
@@ -390,7 +390,12 @@ class Colors extends Module {
 			)
 		);
 
-		$element->start_controls_tabs( 'ang_global_colors_section_tabs' );
+		$element->start_controls_tabs(
+			'ang_global_colors_section_tabs',
+			array(
+				'separator' => 'before',
+			)
+		);
 
 		$element->start_controls_tab(
 			'ang_tab_global_colors_primary',
@@ -538,7 +543,7 @@ class Colors extends Module {
 					'remove' => false,
 					'sort'   => false,
 				),
-				'separator'    => 'after',
+				'separator'    => 'before',
 			)
 		);
 
@@ -577,7 +582,7 @@ class Colors extends Module {
 					'remove' => false,
 					'sort'   => false,
 				),
-				'separator'    => 'after',
+				'separator'    => '',
 			)
 		);
 

--- a/inc/elementor/class-colors.php
+++ b/inc/elementor/class-colors.php
@@ -503,7 +503,6 @@ class Colors extends Module {
 			)
 		);
 
-
 		// Text Colors.
 		$default_type_colors = array(
 			array(
@@ -582,6 +581,12 @@ class Colors extends Module {
 			)
 		);
 
+		$element->end_controls_tab();
+
+		do_action( 'analog_global_colors_tab_end', $element, $repeater );
+
+		$element->end_controls_tabs();
+
 		$element->add_control(
 			'ang_global_reset_colors',
 			array(
@@ -591,12 +596,6 @@ class Colors extends Module {
 				'event' => 'analog:resetGlobalColors',
 			)
 		);
-
-		$element->end_controls_tab();
-
-		do_action( 'analog_global_colors_tab_end', $element, $repeater );
-
-		$element->end_controls_tabs();
 
 		$element->end_controls_section();
 	}

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -1918,15 +1918,12 @@ class Typography extends Module {
 	}
 
 	/**
-	 * Tweak Common widgets for Box Shadow presets.
-	 *
-	 * @param Element_Base $element Element_Base Class.
+	 * Gets set Box Shadow presets.
 	 */
-	public function tweak_common_borders( Element_Base $element ) {
-
+	public function get_kit_shadow_presets() {
 		// Register default options array.
 		$options = array(
-			'none' => __( 'None', 'ang-pro' ),
+			'none' => __( 'None', 'ang' ),
 		);
 
 		/**
@@ -1935,22 +1932,47 @@ class Typography extends Module {
 		$kit = Utils::get_document_kit( get_the_ID() );
 
 		if ( $kit ) {
+			$controls = array(
+				'ang_box_shadows',
+				'ang_box_shadows_secondary',
+				'ang_box_shadows_tertiary',
+			);
+
 			// Use raw settings that doesn't have default values.
 			$kit_raw_settings = $kit->get_data( 'settings' );
 
-			// Get SK Box Shadow preset labels.
-			if ( isset( $kit_raw_settings['ang_box_shadows'] ) ) {
-				$shadow_items = $kit_raw_settings['ang_box_shadows'];
-			} else {
-				// Get default items, but without empty defaults.
-				$control      = $kit->get_controls( 'ang_box_shadows' );
-				$shadow_items = $control['default'];
-			}
+			foreach ( $controls as $control ) {
+				// Get SK Container padding preset labels.
+				if ( isset( $kit_raw_settings[ $control ] ) ) {
+					$shadow_items = $kit_raw_settings[ $control ];
+				} else {
+					// Get default items, but without empty defaults.
+					$control      = $kit->get_controls( $control );
+					$shadow_items = $control['default'] ?? array();
+				}
 
-			foreach ( $shadow_items as $shadow ) {
-				$options[ $shadow['_id'] ] = $shadow['title'];
+				if ( ! empty( $shadow_items ) ) {
+					foreach ( $shadow_items as $shadow ) {
+						if ( isset( $shadow['shadow_box_shadow_type'] ) && 'yes' === $shadow['shadow_box_shadow_type'] ) {
+							$options[ $shadow['_id'] ] = $shadow['title'];
+						}
+					}
+				}
 			}
 		}
+
+		return $options;
+	}
+
+	/**
+	 * Tweak Common widgets for Box Shadow presets.
+	 *
+	 * @param Element_Base $element Element_Base Class.
+	 */
+	public function tweak_common_borders( Element_Base $element ) {
+
+		// Get presets options array.
+		$options = $this->get_kit_shadow_presets();
 
 		/**
 		 * Common widgets.
@@ -2013,33 +2035,8 @@ class Typography extends Module {
 	 */
 	public function tweak_section_column_borders( Element_Base $element ) {
 
-		// Register default options array.
-		$options = array(
-			'none' => __( 'None', 'ang-pro' ),
-		);
-
-		/**
-		 * Get current kit settings.
-		 */
-		$kit = Utils::get_document_kit( get_the_ID() );
-
-		if ( $kit ) {
-			// Use raw settings that doesn't have default values.
-			$kit_raw_settings = $kit->get_data( 'settings' );
-
-			// Get SK Box Shadow preset labels.
-			if ( isset( $kit_raw_settings['ang_box_shadows'] ) ) {
-				$shadow_items = $kit_raw_settings['ang_box_shadows'];
-			} else {
-				// Get default items, but without empty defaults.
-				$control      = $kit->get_controls( 'ang_box_shadows' );
-				$shadow_items = $control['default'];
-			}
-
-			foreach ( $shadow_items as $shadow ) {
-				$options[ $shadow['_id'] ] = $shadow['title'];
-			}
-		}
+		// Get presets options array.
+		$options = $this->get_kit_shadow_presets();
 
 		/**
 		 * Column & Section widgets.
@@ -2101,33 +2098,8 @@ class Typography extends Module {
 	 * @param Element_Base $element Element_Base Class.
 	 */
 	public function tweak_container_borders( Element_Base $element ) {
-		// Register default options array.
-		$options = array(
-			'none' => __( 'None', 'ang-pro' ),
-		);
-
-		/**
-		 * Get current kit settings.
-		 */
-		$kit = Utils::get_document_kit( get_the_ID() );
-
-		if ( $kit ) {
-			// Use raw settings that doesn't have default values.
-			$kit_raw_settings = $kit->get_data( 'settings' );
-
-			// Get SK Box Shadow preset labels.
-			if ( isset( $kit_raw_settings['ang_box_shadows'] ) ) {
-				$shadow_items = $kit_raw_settings['ang_box_shadows'];
-			} else {
-				// Get default items, but without empty defaults.
-				$control      = $kit->get_controls( 'ang_box_shadows' );
-				$shadow_items = $control['default'];
-			}
-
-			foreach ( $shadow_items as $shadow ) {
-				$options[ $shadow['_id'] ] = $shadow['title'];
-			}
-		}
+		// Get presets options array.
+		$options = $this->get_kit_shadow_presets();
 
 		/**
 		 * Container.

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -1550,7 +1550,12 @@ class Typography extends Module {
 			)
 		);
 
-		$element->start_controls_tabs( 'ang_global_fonts_section_tabs' );
+		$element->start_controls_tabs(
+			'ang_global_fonts_section_tabs',
+			array(
+				'separator' => 'before',
+			)
+		);
 
 		$element->start_controls_tab(
 			'ang_tab_global_fonts_primary',
@@ -1672,7 +1677,6 @@ class Typography extends Module {
 					'remove' => false,
 					'sort'   => false,
 				),
-				'separator'    => 'after',
 			)
 		);
 
@@ -1722,7 +1726,7 @@ class Typography extends Module {
 					'remove' => false,
 					'sort'   => false,
 				),
-				'separator'    => 'after',
+				'separator'    => 'before',
 			)
 		);
 

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -1550,6 +1550,13 @@ class Typography extends Module {
 			)
 		);
 
+		$element->start_controls_tabs( 'ang_global_fonts_section_tabs' );
+
+		$element->start_controls_tab(
+			'ang_tab_global_fonts_primary',
+			array( 'label' => __( '1-16', 'ang' ) )
+		);
+
 		$repeater = new Repeater();
 
 		$repeater->add_control(
@@ -1718,6 +1725,12 @@ class Typography extends Module {
 				'separator'    => 'after',
 			)
 		);
+
+		$element->end_controls_tab();
+
+		do_action( 'analog_global_fonts_tab_end', $element, $repeater );
+
+		$element->end_controls_tabs();
 
 		$element->add_control(
 			'ang_global_reset_fonts',

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -110,6 +110,16 @@ class Typography extends Module {
 
 		add_action( 'elementor/element/heading/section_title/after_section_end', array( $this, 'add_typo_helper_link' ), 999, 2 );
 		add_action( 'elementor/element/button/section_button/after_section_end', array( $this, 'add_btn_sizes_helper_link' ), 999, 2 );
+
+		add_action( 'elementor/element/kit/section_buttons/after_section_end', array( $this, 'register_shadows' ), 47, 2 );
+
+		add_action( 'elementor/element/common/_section_border/before_section_end', array( $this, 'tweak_common_borders' ) );
+		add_action( 'elementor/element/section/section_border/before_section_end', array( $this, 'tweak_section_column_borders' ) );
+		add_action( 'elementor/element/column/section_border/before_section_end', array( $this, 'tweak_section_column_borders' ) );
+
+		if ( 'active' === $container_spacing_experiment ) {
+			add_action( 'elementor/element/container/section_border/before_section_end', array( $this, 'tweak_container_borders' ) );
+		}
 	}
 
 	/**
@@ -1747,6 +1757,430 @@ class Typography extends Module {
 		);
 
 		$element->end_controls_section();
+	}
+
+	/**
+	 * Register Global Shadow controls.
+	 *
+	 * @param Controls_Stack $element Controls object.
+	 * @param string         $section_id Section ID.
+	 */
+	public function register_shadows( Controls_Stack $element, $section_id ) {
+		$element->start_controls_section(
+			'ang_shadows',
+			array(
+				'label' => __( 'Shadows', 'ang' ),
+				'tab'   => Utils::get_kit_settings_tab(),
+			)
+		);
+
+		$element->add_control(
+			'ang_shadows_description',
+			array(
+				'raw'             => __( 'Add global shadow presets by using these controls.', 'ang' ),
+				'type'            => Controls_Manager::RAW_HTML,
+				'content_classes' => 'elementor-descriptor',
+			)
+		);
+
+		$element->start_controls_tabs( 'ang_shadows_tabs' );
+
+		$element->start_controls_tab(
+			'ang_tab_shadows_primary',
+			array(
+				'label' => __( '1-8', 'ang' ),
+			)
+		);
+
+		$shadow_defaults = array(
+			array(
+				'_id'   => 'shadow_1',
+				'title' => __( 'Default', 'ang' ),
+			),
+			array(
+				'_id'                    => 'shadow_2',
+				'title'                  => __( 'Small', 'ang' ),
+				'shadow_box_shadow_type' => 'yes',
+				'shadow_box_shadow'      => array(
+					'horizontal' => 0,
+					'vertical'   => 4,
+					'blur'       => 16,
+					'spread'     => 0,
+					'color'      => 'rgba(0,0,0,0.15)',
+				),
+			),
+			array(
+				'_id'                    => 'shadow_3',
+				'title'                  => __( 'Medium', 'ang' ),
+				'shadow_box_shadow_type' => 'yes',
+				'shadow_box_shadow'      => array(
+					'horizontal' => 0,
+					'vertical'   => 20,
+					'blur'       => 20,
+					'spread'     => 0,
+					'color'      => 'rgba(0,0,0,0.15)',
+				),
+			),
+			array(
+				'_id'                    => 'shadow_4',
+				'title'                  => __( 'Large', 'ang' ),
+				'shadow_box_shadow_type' => 'yes',
+				'shadow_box_shadow'      => array(
+					'horizontal' => 0,
+					'vertical'   => 30,
+					'blur'       => 55,
+					'spread'     => 0,
+					'color'      => 'rgba(0,0,0,0.15)',
+				),
+			),
+			array(
+				'_id'                    => 'shadow_5',
+				'title'                  => __( 'Extra Large', 'ang' ),
+				'shadow_box_shadow_type' => 'yes',
+				'shadow_box_shadow'      => array(
+					'horizontal' => 0,
+					'vertical'   => 80,
+					'blur'       => 80,
+					'spread'     => 0,
+					'color'      => 'rgba(0,0,0,0.15)',
+				),
+			),
+			array(
+				'_id'   => 'shadow_6',
+				'title' => __( 'style 6', 'ang' ),
+			),
+			array(
+				'_id'   => 'shadow_7',
+				'title' => __( 'style 7', 'ang' ),
+			),
+			array(
+				'_id'   => 'shadow_8',
+				'title' => __( 'style 8', 'ang' ),
+			),
+		);
+
+		$repeater = new Repeater();
+
+		$repeater->add_control(
+			'title',
+			array(
+				'type'        => Controls_Manager::TEXT,
+				'label_block' => true,
+				'required'    => true,
+			)
+		);
+
+		$repeater->add_group_control(
+			Group_Control_Box_Shadow::get_type(),
+			array(
+				'name'     => 'shadow',
+				'label'    => '',
+				'global'   => array(
+					'active' => false,
+				),
+				'selector' => '{{WRAPPER}} {{CURRENT_ITEM}}.elementor-element > .elementor-widget-container, {{WRAPPER}} {{CURRENT_ITEM}}_hover.elementor-element:hover > .elementor-widget-container, {{WRAPPER}} {{CURRENT_ITEM}}.elementor-element .elementor-element-populated, {{WRAPPER}} {{CURRENT_ITEM}}_hover.elementor-element:hover .elementor-element-populated, {{WRAPPER}} {{CURRENT_ITEM}}.e-container, {{WRAPPER}} {{CURRENT_ITEM}}_hover.e-container:hover',
+			)
+		);
+
+		$element->add_control(
+			'ang_box_shadows',
+			array(
+				'type'         => Global_Style_Repeater::CONTROL_TYPE,
+				'fields'       => $repeater->get_controls(),
+				'default'      => $shadow_defaults,
+				'item_actions' => array(
+					'add'       => false,
+					'remove'    => false,
+					'sort'      => false,
+					'duplicate' => false,
+				),
+				'separator'    => 'after',
+			)
+		);
+
+		$element->end_controls_tab();
+
+		do_action( 'analog_box_shadows_tab_end', $element, $repeater );
+
+		$element->end_controls_tabs();
+
+		$element->add_control(
+			'ang_box_shadows_reset',
+			array(
+				'label' => __( 'Reset to default', 'ang' ),
+				'type'  => 'button',
+				'text'  => __( 'Reset', 'ang' ),
+				'event' => 'analog:resetBoxShadows',
+			)
+		);
+
+		$element->end_controls_section();
+	}
+
+	/**
+	 * Tweak Common widgets for Box Shadow presets.
+	 *
+	 * @param Element_Base $element Element_Base Class.
+	 */
+	public function tweak_common_borders( Element_Base $element ) {
+
+		// Register default options array.
+		$options = array(
+			'none' => __( 'None', 'ang-pro' ),
+		);
+
+		/**
+		 * Get current kit settings.
+		 */
+		$kit = Utils::get_document_kit( get_the_ID() );
+
+		if ( $kit ) {
+			// Use raw settings that doesn't have default values.
+			$kit_raw_settings = $kit->get_data( 'settings' );
+
+			// Get SK Box Shadow preset labels.
+			if ( isset( $kit_raw_settings['ang_box_shadows'] ) ) {
+				$shadow_items = $kit_raw_settings['ang_box_shadows'];
+			} else {
+				// Get default items, but without empty defaults.
+				$control      = $kit->get_controls( 'ang_box_shadows' );
+				$shadow_items = $control['default'];
+			}
+
+			foreach ( $shadow_items as $shadow ) {
+				$options[ $shadow['_id'] ] = $shadow['title'];
+			}
+		}
+
+		/**
+		 * Common widgets.
+		 */
+		$element->start_injection(
+			array(
+				'tab' => '_tab_border_normal',
+				'of'  => '_box_shadow_box_shadow_type',
+				'at'  => 'before',
+			)
+		);
+
+		$element->add_control(
+			'ang_box_shadow_preset',
+			array(
+				'label'         => __( 'Box Shadow Preset', 'ang-pro' ),
+				'type'          => Controls_Manager::SELECT,
+				'hide_in_inner' => true,
+				'default'       => 'none',
+				'options'       => $options,
+				'prefix_class'  => 'elementor-repeater-item-',
+			)
+		);
+
+		$element->end_injection();
+
+		$element->start_injection(
+			array(
+				'tab' => '_tab_border_hover',
+				'of'  => '_box_shadow_hover_box_shadow_type',
+				'at'  => 'before',
+			)
+		);
+
+		$hover_options = array();
+
+		foreach ( $options as $key => $value ) {
+			$hover_options[ $key . '_hover' ] = $value;
+		}
+
+		$element->add_control(
+			'ang_box_shadow_hover_preset',
+			array(
+				'label'         => __( 'Box Shadow Preset', 'ang-pro' ),
+				'type'          => Controls_Manager::SELECT,
+				'hide_in_inner' => true,
+				'default'       => 'none',
+				'options'       => $hover_options,
+				'prefix_class'  => 'elementor-repeater-item-',
+			)
+		);
+
+		$element->end_injection();
+	}
+
+	/**
+	 * Tweak Section & Column widgets for Box Shadow presets.
+	 *
+	 * @param Element_Base $element Element_Base Class.
+	 */
+	public function tweak_section_column_borders( Element_Base $element ) {
+
+		// Register default options array.
+		$options = array(
+			'none' => __( 'None', 'ang-pro' ),
+		);
+
+		/**
+		 * Get current kit settings.
+		 */
+		$kit = Utils::get_document_kit( get_the_ID() );
+
+		if ( $kit ) {
+			// Use raw settings that doesn't have default values.
+			$kit_raw_settings = $kit->get_data( 'settings' );
+
+			// Get SK Box Shadow preset labels.
+			if ( isset( $kit_raw_settings['ang_box_shadows'] ) ) {
+				$shadow_items = $kit_raw_settings['ang_box_shadows'];
+			} else {
+				// Get default items, but without empty defaults.
+				$control      = $kit->get_controls( 'ang_box_shadows' );
+				$shadow_items = $control['default'];
+			}
+
+			foreach ( $shadow_items as $shadow ) {
+				$options[ $shadow['_id'] ] = $shadow['title'];
+			}
+		}
+
+		/**
+		 * Column & Section widgets.
+		 */
+		$element->start_injection(
+			array(
+				'tab' => 'tab_border_normal',
+				'of'  => 'box_shadow_box_shadow_type',
+				'at'  => 'before',
+			)
+		);
+
+		$element->add_control(
+			'ang_sc_box_shadow_preset',
+			array(
+				'label'         => __( 'Box Shadow Preset', 'ang-pro' ),
+				'type'          => Controls_Manager::SELECT,
+				'hide_in_inner' => true,
+				'default'       => 'none',
+				'options'       => $options,
+				'prefix_class'  => 'elementor-repeater-item-',
+			)
+		);
+
+		$element->end_injection();
+
+		$element->start_injection(
+			array(
+				'tab' => 'tab_border_hover',
+				'of'  => 'box_shadow_hover_box_shadow_type',
+				'at'  => 'before',
+			)
+		);
+
+		$hover_options = array();
+
+		foreach ( $options as $key => $value ) {
+			$hover_options[ $key . '_hover' ] = $value;
+		}
+
+		$element->add_control(
+			'ang_sc_box_shadow_hover_preset',
+			array(
+				'label'         => __( 'Box Shadow Preset', 'ang-pro' ),
+				'type'          => Controls_Manager::SELECT,
+				'hide_in_inner' => true,
+				'default'       => 'none',
+				'options'       => $hover_options,
+				'prefix_class'  => 'elementor-repeater-item-',
+			)
+		);
+
+		$element->end_injection();
+	}
+
+	/**
+	 * Tweak Container widget for Box Shadow presets.
+	 *
+	 * @param Element_Base $element Element_Base Class.
+	 */
+	public function tweak_container_borders( Element_Base $element ) {
+		// Register default options array.
+		$options = array(
+			'none' => __( 'None', 'ang-pro' ),
+		);
+
+		/**
+		 * Get current kit settings.
+		 */
+		$kit = Utils::get_document_kit( get_the_ID() );
+
+		if ( $kit ) {
+			// Use raw settings that doesn't have default values.
+			$kit_raw_settings = $kit->get_data( 'settings' );
+
+			// Get SK Box Shadow preset labels.
+			if ( isset( $kit_raw_settings['ang_box_shadows'] ) ) {
+				$shadow_items = $kit_raw_settings['ang_box_shadows'];
+			} else {
+				// Get default items, but without empty defaults.
+				$control      = $kit->get_controls( 'ang_box_shadows' );
+				$shadow_items = $control['default'];
+			}
+
+			foreach ( $shadow_items as $shadow ) {
+				$options[ $shadow['_id'] ] = $shadow['title'];
+			}
+		}
+
+		/**
+		 * Container.
+		 */
+		$element->start_injection(
+			array(
+				'tab' => 'tab_border',
+				'of'  => 'box_shadow_box_shadow_type',
+				'at'  => 'before',
+			)
+		);
+
+		$element->add_control(
+			'ang_container_box_shadow_preset',
+			array(
+				'label'         => __( 'Box Shadow Preset', 'ang-pro' ),
+				'type'          => Controls_Manager::SELECT,
+				'hide_in_inner' => true,
+				'default'       => 'none',
+				'options'       => $options,
+				'prefix_class'  => 'elementor-repeater-item-',
+			)
+		);
+
+		$element->end_injection();
+
+		$element->start_injection(
+			array(
+				'tab' => 'tab_border_hover',
+				'of'  => 'box_shadow_hover_box_shadow_type',
+				'at'  => 'before',
+			)
+		);
+
+		$hover_options = array();
+
+		foreach ( $options as $key => $value ) {
+			$hover_options[ $key . '_hover' ] = $value;
+		}
+
+		$element->add_control(
+			'ang_container_box_shadow_hover_preset',
+			array(
+				'label'         => __( 'Box Shadow Preset', 'ang-pro' ),
+				'type'          => Controls_Manager::SELECT,
+				'hide_in_inner' => true,
+				'default'       => 'none',
+				'options'       => $hover_options,
+				'prefix_class'  => 'elementor-repeater-item-',
+			)
+		);
+
+		$element->end_injection();
 	}
 
 	/**

--- a/inc/elementor/globals/class-colors.php
+++ b/inc/elementor/globals/class-colors.php
@@ -49,6 +49,10 @@ class Colors extends Base {
 			'ang_global_accent_colors',
 			'ang_global_text_colors',
 			'ang_global_extra_colors',
+			'ang_global_secondary_part_one_colors',
+			'ang_global_secondary_part_two_colors',
+			'ang_global_tertiary_part_one_colors',
+			'ang_global_tertiary_part_two_colors',
 		);
 
 		foreach ( $color_keys as $color_key ) {

--- a/inc/elementor/globals/class-colors.php
+++ b/inc/elementor/globals/class-colors.php
@@ -69,8 +69,8 @@ class Colors extends Base {
 			$id            = $item['_id'];
 			$result[ $id ] = array(
 				'id'    => $id,
-				'title' => $item['title'],
-				'value' => $item['color'],
+				'title' => $item['title'] ?? '',
+				'value' => $item['color'] ?? '',
 			);
 		}
 

--- a/inc/elementor/globals/class-typography.php
+++ b/inc/elementor/globals/class-typography.php
@@ -54,6 +54,10 @@ class Typography extends Base {
 		$font_keys = array(
 			'ang_global_title_fonts',
 			'ang_global_text_fonts',
+			'ang_global_secondary_part_one_fonts',
+			'ang_global_secondary_part_two_fonts',
+			'ang_global_tertiary_part_one_fonts',
+			'ang_global_tertiary_part_two_fonts',
 		);
 
 		foreach ( $font_keys as $font_key ) {

--- a/inc/elementor/globals/class-typography.php
+++ b/inc/elementor/globals/class-typography.php
@@ -91,7 +91,7 @@ class Typography extends Base {
 			$id = $item['_id'];
 
 			$result[ $id ] = array(
-				'title' => $item['title'],
+				'title' => $item['title'] ?? '',
 				'id'    => $id,
 			);
 

--- a/inc/elementor/js/ang-action.js
+++ b/inc/elementor/js/ang-action.js
@@ -656,9 +656,48 @@ jQuery( window ).on( 'elementor/init', function() {
 		} ).show();
 	};
 
+	analog.resetBoxShadows = () => {
+		const ang_box_shadows = [
+			'ang_box_shadows',
+			'ang_box_shadows_secondary',
+			'ang_box_shadows_tertiary'
+		];
+
+		const defaultValues = {};
+
+		// Get defaults for each setting
+		ang_box_shadows.forEach( ( setting ) => defaultValues[ setting ] = elementor.documents.documents[ elementor.config.kit_id ].container.controls[ setting ].default );
+
+		// Reset the selected settings to their default values
+		$e.run( 'document/elements/settings', {
+			container: elementor.documents.documents[ elementor.config.kit_id ].container,
+			settings: defaultValues,
+			options: {
+				external: true,
+			},
+		} );
+
+		// Reset value render hack.
+		$e.run( 'document/save/update' ).then( () => $e.run( 'panel/global/close' ).then( () => analog.redirectToPanel( 'ang_shadows' ) ) );
+	};
+
+	analog.handleResetBoxShadows = () => {
+		elementorCommon.dialogsManager.createWidget( 'confirm', {
+			message: ANG_Action.translate.resetShadowsDesc,
+			headerMessage: ANG_Action.translate.resetHeader,
+			strings: {
+				confirm: elementor.translate( 'yes' ),
+				cancel: elementor.translate( 'cancel' ),
+			},
+			defaultOption: 'cancel',
+			onConfirm: analog.resetBoxShadows,
+		} ).show();
+	};
+
 	elementor.channels.editor.on( 'analog:resetContainerPadding', analog.handleContainerPaddingReset );
 	elementor.channels.editor.on( 'analog:resetGlobalColors', analog.handleGlobalColorsReset );
 	elementor.channels.editor.on( 'analog:resetGlobalFonts', analog.handleGlobalFontsReset );
+	elementor.channels.editor.on( 'analog:resetBoxShadows', analog.handleResetBoxShadows );
 	elementor.channels.editor.on( 'analog:resetKit', analog.handleCSSReset );
 	elementor.channels.editor.on( 'analog:saveKit', analog.handleSaveToken );
 	elementor.channels.editor.on( 'analog:exportCSS', analog.handleCSSExport );

--- a/inc/elementor/js/ang-action.js
+++ b/inc/elementor/js/ang-action.js
@@ -541,6 +541,10 @@ jQuery( window ).on( 'elementor/init', function() {
 				'ang_global_accent_colors',
 				'ang_global_text_colors',
 				'ang_global_extra_colors',
+				'ang_global_secondary_part_one_colors',
+				'ang_global_secondary_part_two_colors',
+				'ang_global_tertiary_part_one_colors',
+				'ang_global_tertiary_part_two_colors',
 			];
 
 		let defaultValues = {};
@@ -578,6 +582,10 @@ jQuery( window ).on( 'elementor/init', function() {
 		const ang_global_fonts = [
 			'ang_global_title_fonts',
 			'ang_global_text_fonts',
+			'ang_global_secondary_part_one_fonts',
+			'ang_global_secondary_part_two_fonts',
+			'ang_global_tertiary_part_one_fonts',
+			'ang_global_tertiary_part_two_fonts',
 		];
 
 		let defaultValues = {};


### PR DESCRIPTION
### How to test
1. Go to Elementor editor screen, open Site settings.
3. From Site settings, go to Style Kits >> Shadows.
4. Add/update a few options and select them at any widget's border styles for Box Shadow Preset control.
5. Test Reset button, it should reset options to their default state.