### PR TITLE
Improve Container Spacing 

### DIFF
--- a/assets/css/sk-components.css
+++ b/assets/css/sk-components.css
@@ -334,7 +334,6 @@
  */
 
 .elementor-control.elementor-control-ang_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-fields,
-.elementor-control.elementor-control-ang_container_padding_part_two.elementor-control-type-global-style-repeater .elementor-repeater-fields,
 .elementor-control.elementor-control-ang_container_padding_secondary.elementor-control-type-global-style-repeater .elementor-repeater-fields,
 .elementor-control.elementor-control-ang_container_padding_tertiary.elementor-control-type-global-style-repeater .elementor-repeater-fields,
 .elementor-control.elementor-control-ang_custom_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-fields {
@@ -343,7 +342,6 @@
 }
 
 .elementor-control.elementor-control-ang_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-tool-remove--disabled,
-.elementor-control.elementor-control-ang_container_padding_part_two.elementor-control-type-global-style-repeater .elementor-repeater-tool-remove--disabled,
 .elementor-control.elementor-control-ang_container_padding_secondary.elementor-control-type-global-style-repeater .elementor-repeater-tool-remove--disabled,
 .elementor-control.elementor-control-ang_container_padding_tertiary.elementor-control-type-global-style-repeater .elementor-repeater-tool-remove--disabled,
 .elementor-control.elementor-control-ang_custom_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-tool-remove--disabled {
@@ -358,7 +356,6 @@
 }
 
 .elementor-control.elementor-control-ang_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-row-controls,
-.elementor-control.elementor-control-ang_container_padding_part_two.elementor-control-type-global-style-repeater .elementor-repeater-row-controls,
 .elementor-control.elementor-control-ang_container_padding_secondary.elementor-control-type-global-style-repeater .elementor-repeater-row-controls,
 .elementor-control.elementor-control-ang_container_padding_tertiary.elementor-control-type-global-style-repeater .elementor-repeater-row-controls,
 .elementor-control.elementor-control-ang_custom_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-row-controls {
@@ -368,7 +365,6 @@
 }
 
 .elementor-control.elementor-control-ang_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-control-responsive-switchers,
-.elementor-control.elementor-control-ang_container_padding_part_two.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-control-responsive-switchers,
 .elementor-control.elementor-control-ang_container_padding_secondary.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-control-responsive-switchers,
 .elementor-control.elementor-control-ang_container_padding_tertiary.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-control-responsive-switchers,
 .elementor-control.elementor-control-ang_custom_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-control-responsive-switchers {
@@ -383,7 +379,6 @@
 }
 
 .elementor-control.elementor-control-ang_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-units-choices,
-.elementor-control.elementor-control-ang_container_padding_part_two.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-units-choices,
 .elementor-control.elementor-control-ang_container_padding_secondary.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-units-choices,
 .elementor-control.elementor-control-ang_container_padding_tertiary.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-units-choices,
 .elementor-control.elementor-control-ang_custom_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-units-choices {

--- a/assets/css/sk-components.css
+++ b/assets/css/sk-components.css
@@ -334,12 +334,18 @@
  */
 
 .elementor-control.elementor-control-ang_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-fields,
+.elementor-control.elementor-control-ang_container_padding_part_two.elementor-control-type-global-style-repeater .elementor-repeater-fields,
+.elementor-control.elementor-control-ang_container_padding_secondary.elementor-control-type-global-style-repeater .elementor-repeater-fields,
+.elementor-control.elementor-control-ang_container_padding_tertiary.elementor-control-type-global-style-repeater .elementor-repeater-fields,
 .elementor-control.elementor-control-ang_custom_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-fields {
 	margin-bottom: 25px;
 	display: flex;
 }
 
 .elementor-control.elementor-control-ang_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-tool-remove--disabled,
+.elementor-control.elementor-control-ang_container_padding_part_two.elementor-control-type-global-style-repeater .elementor-repeater-tool-remove--disabled,
+.elementor-control.elementor-control-ang_container_padding_secondary.elementor-control-type-global-style-repeater .elementor-repeater-tool-remove--disabled,
+.elementor-control.elementor-control-ang_container_padding_tertiary.elementor-control-type-global-style-repeater .elementor-repeater-tool-remove--disabled,
 .elementor-control.elementor-control-ang_custom_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-tool-remove--disabled {
 	display: none;
 }
@@ -352,6 +358,9 @@
 }
 
 .elementor-control.elementor-control-ang_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-row-controls,
+.elementor-control.elementor-control-ang_container_padding_part_two.elementor-control-type-global-style-repeater .elementor-repeater-row-controls,
+.elementor-control.elementor-control-ang_container_padding_secondary.elementor-control-type-global-style-repeater .elementor-repeater-row-controls,
+.elementor-control.elementor-control-ang_container_padding_tertiary.elementor-control-type-global-style-repeater .elementor-repeater-row-controls,
 .elementor-control.elementor-control-ang_custom_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-row-controls {
 	flex-direction: column;
 	gap: 8px;
@@ -359,6 +368,9 @@
 }
 
 .elementor-control.elementor-control-ang_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-control-responsive-switchers,
+.elementor-control.elementor-control-ang_container_padding_part_two.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-control-responsive-switchers,
+.elementor-control.elementor-control-ang_container_padding_secondary.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-control-responsive-switchers,
+.elementor-control.elementor-control-ang_container_padding_tertiary.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-control-responsive-switchers,
 .elementor-control.elementor-control-ang_custom_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-control-responsive-switchers {
 	top: -35px;
 	left: 135px;
@@ -371,6 +383,13 @@
 }
 
 .elementor-control.elementor-control-ang_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-units-choices,
+.elementor-control.elementor-control-ang_container_padding_part_two.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-units-choices,
+.elementor-control.elementor-control-ang_container_padding_secondary.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-units-choices,
+.elementor-control.elementor-control-ang_container_padding_tertiary.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-units-choices,
 .elementor-control.elementor-control-ang_custom_container_padding.elementor-control-type-global-style-repeater .elementor-repeater-fields .elementor-control-type-dimensions.elementor-control-separator-default .elementor-units-choices {
 	margin-top: -50px;
+}
+
+.elementor-control.elementor-control-ang_container_padding {
+	padding-bottom: 0;
 }

--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -41,7 +41,13 @@ final class Promotions extends Base {
 		$global_colors_experiment = Options::get_instance()->get( 'global_colors_experiment' );
 
 		if ( 'active' === $global_colors_experiment ) {
-			add_action( 'analog_global_colors_tab_end', array( $this, 'add_additional_tabs_promo' ), 170, 2 );
+			add_action( 'analog_global_colors_tab_end', array( $this, 'add_additional_color_tabs_promo' ), 170, 2 );
+		}
+
+		$global_fonts_experiment = Options::get_instance()->get( 'global_fonts_experiment' );
+
+		if ( 'active' === $global_fonts_experiment ) {
+			add_action( 'analog_global_fonts_tab_end', array( $this, 'add_additional_font_tabs_promo' ), 170, 2 );
 		}
 	}
 
@@ -336,7 +342,6 @@ final class Promotions extends Base {
 		);
 	}
 
-
 	/**
 	 * Modify original "Style Kit Colors" tabs.
 	 *
@@ -345,7 +350,7 @@ final class Promotions extends Base {
 	 * @param Controls_Stack $element Elementor element.
 	 * @param Repeater       $repeater Elementor repeater element.
 	 */
-	public function add_additional_tabs_promo( Controls_Stack $element, Repeater $repeater ) {
+	public function add_additional_color_tabs_promo( Controls_Stack $element, Repeater $repeater ) {
 		$element->start_controls_tab(
 			'ang_tab_global_colors_secondary',
 			array( 'label' => __( '17-32', 'ang' ) )
@@ -358,7 +363,7 @@ final class Promotions extends Base {
 				'raw'  => $this->get_updated_teaser_template(
 					array(
 						'messages' => array(
-							__( 'Extend your color system with more variables, plus many more features with Style Kist Pro.', 'ang' ),
+							__( 'Extend your color system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
 						),
 						'link'     => array( 'utm_source' => 'ang-global-colors' ),
 					)
@@ -380,9 +385,63 @@ final class Promotions extends Base {
 				'raw'  => $this->get_updated_teaser_template(
 					array(
 						'messages' => array(
-							__( 'Extend your color system with more variables, plus many more features with Style Kist Pro.', 'ang' ),
+							__( 'Extend your color system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
 						),
 						'link'     => array( 'utm_source' => 'ang-global-colors' ),
+					)
+				),
+			)
+		);
+
+		$element->end_controls_tab();
+	}
+
+	/**
+	 * Modify original "Style Kit Fonts" tabs.
+	 *
+	 * @hook analog_global_fonts_tab_end
+	 *
+	 * @param Controls_Stack $element Elementor element.
+	 * @param Repeater       $repeater Elementor repeater element.
+	 */
+	public function add_additional_font_tabs_promo( Controls_Stack $element, Repeater $repeater ) {
+		$element->start_controls_tab(
+			'ang_tab_global_fonts_secondary',
+			array( 'label' => __( '17-32', 'ang' ) )
+		);
+
+		$element->add_control(
+			'ang_global_fonts_secondary_tab_promo',
+			array(
+				'type' => Controls_Manager::RAW_HTML,
+				'raw'  => $this->get_updated_teaser_template(
+					array(
+						'messages' => array(
+							__( 'Extend your typography system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
+						),
+						'link'     => array( 'utm_source' => 'ang-global-fonts' ),
+					)
+				),
+			)
+		);
+
+		$element->end_controls_tab();
+
+		$element->start_controls_tab(
+			'ang_tab_global_fonts_tertiary',
+			array( 'label' => __( '33-64', 'ang' ) )
+		);
+
+		$element->add_control(
+			'ang_global_fonts_tertiary_tab_promo',
+			array(
+				'type' => Controls_Manager::RAW_HTML,
+				'raw'  => $this->get_updated_teaser_template(
+					array(
+						'messages' => array(
+							__( 'Extend your typography system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
+						),
+						'link'     => array( 'utm_source' => 'ang-global-fonts' ),
 					)
 				),
 			)

--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -37,6 +37,12 @@ final class Promotions extends Base {
 		if ( 'active' === $container_spacing_experiment ) {
 			add_action( 'analog_container_spacing_section_end', array( $this, 'add_container_custom_spacing_promo' ), 170, 2 );
 		}
+
+		$global_colors_experiment = Options::get_instance()->get( 'global_colors_experiment' );
+
+		if ( 'active' === $global_colors_experiment ) {
+			add_action( 'analog_global_colors_tab_end', array( $this, 'add_additional_tabs_promo' ), 170, 2 );
+		}
 	}
 
 	/**
@@ -190,6 +196,50 @@ final class Promotions extends Base {
 	}
 
 	/**
+	 * Get promotional teaser template (Updated).
+	 *
+	 * @since 1.9.3
+	 * @param array $texts Text arguments.
+	 *
+	 * @return false|string
+	 */
+	public function get_updated_teaser_template( $texts ) {
+		ob_start();
+		?>
+		<div class="elementor-nerd-box" style="padding: 0; display: flex; align-items: baseline; gap: 10px; text-align: left;">
+			<div style="align-self: center;">
+
+				<?php
+				if ( $texts['title'] ) :
+					?>
+					<div class="elementor-nerd-box-title"><?php echo $texts['title']; // @codingStandardsIgnoreLine ?></div>
+					<?php
+				endif;
+				foreach ( $texts['messages'] as $message ) {
+					?>
+					<div class="elementor-nerd-box-message"><?php echo $message; // @codingStandardsIgnoreLine ?></div>
+					<?php
+				}
+
+				if ( $texts['link'] ) {
+					?>
+					<a
+							class="elementor-nerd-box-link elementor-button elementor-button-default elementor-button-go-pro"
+							href="<?php echo esc_url( Utils::get_pro_link( $texts['link'] ) ); ?>"
+							style="background-color:var(--ang-accent)"
+							target="_blank">
+						<?php esc_html_e( 'Learn More', 'ang' ); ?>
+					</a>
+				<?php } ?>
+			</div>
+			<img class="elementor-nerd-box-icon" style="width:45px;margin-right:0;" alt="Style Kits for Elementor" src="<?php echo esc_url( ANG_PLUGIN_URL . 'assets/img/analog.svg' ); ?>" />
+		</div>
+		<?php
+
+		return ob_get_clean();
+	}
+
+	/**
 	 * Modify original "Background Color Classes" controls.
 	 *
 	 * @hook analog_background_colors_tab_end
@@ -284,6 +334,61 @@ final class Promotions extends Base {
 				),
 			)
 		);
+	}
+
+
+	/**
+	 * Modify original "Style Kit Colors" tabs.
+	 *
+	 * @hook analog_global_colors_tab_end
+	 *
+	 * @param Controls_Stack $element Elementor element.
+	 * @param Repeater       $repeater Elementor repeater element.
+	 */
+	public function add_additional_tabs_promo( Controls_Stack $element, Repeater $repeater ) {
+		$element->start_controls_tab(
+			'ang_tab_global_colors_secondary',
+			array( 'label' => __( '17-32', 'ang' ) )
+		);
+
+		$element->add_control(
+			'ang_global_colors_secondary_tab_promo',
+			array(
+				'type' => Controls_Manager::RAW_HTML,
+				'raw'  => $this->get_updated_teaser_template(
+					array(
+						'messages' => array(
+							__( 'Extend your color system with more variables, plus many more features with Style Kist Pro.', 'ang' ),
+						),
+						'link'     => array( 'utm_source' => 'ang-global-colors' ),
+					)
+				),
+			)
+		);
+
+		$element->end_controls_tab();
+
+		$element->start_controls_tab(
+			'ang_tab_global_colors_tertiary',
+			array( 'label' => __( '33-64', 'ang' ) )
+		);
+
+		$element->add_control(
+			'ang_global_colors_tertiary_tab_promo',
+			array(
+				'type' => Controls_Manager::RAW_HTML,
+				'raw'  => $this->get_updated_teaser_template(
+					array(
+						'messages' => array(
+							__( 'Extend your color system with more variables, plus many more features with Style Kist Pro.', 'ang' ),
+						),
+						'link'     => array( 'utm_source' => 'ang-global-colors' ),
+					)
+				),
+			)
+		);
+
+		$element->end_controls_tab();
 	}
 }
 

--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -35,7 +35,7 @@ final class Promotions extends Base {
 		$container_spacing_experiment = Options::get_instance()->get( 'container_spacing_experiment' );
 
 		if ( 'active' === $container_spacing_experiment ) {
-			add_action( 'analog_container_spacing_section_end', array( $this, 'add_container_custom_spacing_promo' ), 170, 2 );
+			add_action( 'analog_container_spacing_tabs_end', array( $this, 'add_additional_container_spacing_tabs_promo' ), 170, 2 );
 		}
 
 		$global_colors_experiment = Options::get_instance()->get( 'global_colors_experiment' );
@@ -317,29 +317,57 @@ final class Promotions extends Base {
 	}
 
 	/**
-	 * Modify original "Container Spacing" controls.
+	 * Modify original "Container Spacing" tabs.
 	 *
-	 * @hook analog_container_spacing_section_end
+	 * @hook analog_container_spacing_tabs_end
 	 *
 	 * @param Controls_Stack $element Elementor element.
 	 * @param Repeater       $repeater Elementor repeater element.
 	 */
-	public function add_container_custom_spacing_promo( Controls_Stack $element, Repeater $repeater ) {
+	public function add_additional_container_spacing_tabs_promo( Controls_Stack $element, Repeater $repeater ) {
+		$element->start_controls_tab(
+			'ang_tab_container_spacing_secondary',
+			array( 'label' => __( '9-16', 'ang' ) )
+		);
+
 		$element->add_control(
-			'ang_promo_container_spacing_custom_presets',
+			'ang_container_spacing_secondary_tab_promo',
 			array(
 				'type' => Controls_Manager::RAW_HTML,
-				'raw'  => $this->get_control_teaser_template(
+				'raw'  => $this->get_updated_teaser_template(
 					array(
-						'title'    => __( 'Custom Presets', 'ang' ),
 						'messages' => array(
-							__( 'Add more spacing presets with Style Kits Pro.', 'ang' ),
+							__( 'Extend your container spacing system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
 						),
-						'link'     => array( 'utm_source' => 'custom-container-spacing' ),
+						'link'     => array( 'utm_source' => 'ang-container-spacing' ),
 					)
 				),
 			)
 		);
+
+		$element->end_controls_tab();
+
+		$element->start_controls_tab(
+			'ang_tab_container_spacing_tertiary',
+			array( 'label' => __( '17-24', 'ang' ) )
+		);
+
+		$element->add_control(
+			'ang_container_spacing_tertiary_tab_promo',
+			array(
+				'type' => Controls_Manager::RAW_HTML,
+				'raw'  => $this->get_updated_teaser_template(
+					array(
+						'messages' => array(
+							__( 'Extend your container spacing system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
+						),
+						'link'     => array( 'utm_source' => 'ang-container-spacing' ),
+					)
+				),
+			)
+		);
+
+		$element->end_controls_tab();
 	}
 
 	/**

--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -375,7 +375,7 @@ final class Promotions extends Base {
 
 		$element->start_controls_tab(
 			'ang_tab_global_colors_tertiary',
-			array( 'label' => __( '33-64', 'ang' ) )
+			array( 'label' => __( '33-48', 'ang' ) )
 		);
 
 		$element->add_control(
@@ -429,7 +429,7 @@ final class Promotions extends Base {
 
 		$element->start_controls_tab(
 			'ang_tab_global_fonts_tertiary',
-			array( 'label' => __( '33-64', 'ang' ) )
+			array( 'label' => __( '33-48', 'ang' ) )
 		);
 
 		$element->add_control(

--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -368,6 +368,7 @@ final class Promotions extends Base {
 						'link'     => array( 'utm_source' => 'ang-global-colors' ),
 					)
 				),
+				'separator'    => 'before',
 			)
 		);
 
@@ -381,8 +382,8 @@ final class Promotions extends Base {
 		$element->add_control(
 			'ang_global_colors_tertiary_tab_promo',
 			array(
-				'type' => Controls_Manager::RAW_HTML,
-				'raw'  => $this->get_updated_teaser_template(
+				'type'      => Controls_Manager::RAW_HTML,
+				'raw'       => $this->get_updated_teaser_template(
 					array(
 						'messages' => array(
 							__( 'Extend your color system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
@@ -390,6 +391,7 @@ final class Promotions extends Base {
 						'link'     => array( 'utm_source' => 'ang-global-colors' ),
 					)
 				),
+				'separator' => 'before',
 			)
 		);
 

--- a/inc/elementor/Promotions.php
+++ b/inc/elementor/Promotions.php
@@ -387,8 +387,8 @@ final class Promotions extends Base {
 		$element->add_control(
 			'ang_global_colors_secondary_tab_promo',
 			array(
-				'type' => Controls_Manager::RAW_HTML,
-				'raw'  => $this->get_updated_teaser_template(
+				'type'      => Controls_Manager::RAW_HTML,
+				'raw'       => $this->get_updated_teaser_template(
 					array(
 						'messages' => array(
 							__( 'Extend your color system with more variables, plus many more features with Style Kits Pro.', 'ang' ),
@@ -396,7 +396,7 @@ final class Promotions extends Base {
 						'link'     => array( 'utm_source' => 'ang-global-colors' ),
 					)
 				),
-				'separator'    => 'before',
+				'separator' => 'before',
 			)
 		);
 

--- a/inc/elementor/class-colors.php
+++ b/inc/elementor/class-colors.php
@@ -390,6 +390,13 @@ class Colors extends Module {
 			)
 		);
 
+		$element->start_controls_tabs( 'ang_global_colors_section_tabs' );
+
+		$element->start_controls_tab(
+			'ang_tab_global_colors_primary',
+			array( 'label' => __( '1-16', 'ang' ) )
+		);
+
 		$repeater = new Repeater();
 
 		$repeater->add_control(
@@ -584,6 +591,12 @@ class Colors extends Module {
 				'event' => 'analog:resetGlobalColors',
 			)
 		);
+
+		$element->end_controls_tab();
+
+		do_action( 'analog_global_colors_tab_end', $element, $repeater );
+
+		$element->end_controls_tabs();
 
 		$element->end_controls_section();
 	}

--- a/inc/elementor/class-colors.php
+++ b/inc/elementor/class-colors.php
@@ -390,7 +390,12 @@ class Colors extends Module {
 			)
 		);
 
-		$element->start_controls_tabs( 'ang_global_colors_section_tabs' );
+		$element->start_controls_tabs(
+			'ang_global_colors_section_tabs',
+			array(
+				'separator' => 'before',
+			)
+		);
 
 		$element->start_controls_tab(
 			'ang_tab_global_colors_primary',
@@ -538,7 +543,7 @@ class Colors extends Module {
 					'remove' => false,
 					'sort'   => false,
 				),
-				'separator'    => 'after',
+				'separator'    => 'before',
 			)
 		);
 
@@ -577,7 +582,7 @@ class Colors extends Module {
 					'remove' => false,
 					'sort'   => false,
 				),
-				'separator'    => 'after',
+				'separator'    => '',
 			)
 		);
 

--- a/inc/elementor/class-colors.php
+++ b/inc/elementor/class-colors.php
@@ -503,7 +503,6 @@ class Colors extends Module {
 			)
 		);
 
-
 		// Text Colors.
 		$default_type_colors = array(
 			array(
@@ -582,6 +581,12 @@ class Colors extends Module {
 			)
 		);
 
+		$element->end_controls_tab();
+
+		do_action( 'analog_global_colors_tab_end', $element, $repeater );
+
+		$element->end_controls_tabs();
+
 		$element->add_control(
 			'ang_global_reset_colors',
 			array(
@@ -591,12 +596,6 @@ class Colors extends Module {
 				'event' => 'analog:resetGlobalColors',
 			)
 		);
-
-		$element->end_controls_tab();
-
-		do_action( 'analog_global_colors_tab_end', $element, $repeater );
-
-		$element->end_controls_tabs();
 
 		$element->end_controls_section();
 	}

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -1550,7 +1550,12 @@ class Typography extends Module {
 			)
 		);
 
-		$element->start_controls_tabs( 'ang_global_fonts_section_tabs' );
+		$element->start_controls_tabs(
+			'ang_global_fonts_section_tabs',
+			array(
+				'separator' => 'before',
+			)
+		);
 
 		$element->start_controls_tab(
 			'ang_tab_global_fonts_primary',
@@ -1672,7 +1677,6 @@ class Typography extends Module {
 					'remove' => false,
 					'sort'   => false,
 				),
-				'separator'    => 'after',
 			)
 		);
 
@@ -1722,7 +1726,7 @@ class Typography extends Module {
 					'remove' => false,
 					'sort'   => false,
 				),
-				'separator'    => 'after',
+				'separator'    => 'before',
 			)
 		);
 

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -1212,20 +1212,32 @@ class Typography extends Module {
 		$kit = Utils::get_document_kit( get_the_ID() );
 
 		if ( $kit ) {
+			$controls = array(
+				'ang_container_padding',
+				'ang_container_padding_part_two',
+				'ang_container_padding_secondary',
+				'ang_container_padding_tertiary',
+				'ang_custom_container_padding',
+			);
+
 			// Use raw settings that doesn't have default values.
 			$kit_raw_settings = $kit->get_data( 'settings' );
 
-			// Get SK Container padding preset labels.
-			if ( isset( $kit_raw_settings['ang_container_padding'] ) ) {
-				$padding_items = $kit_raw_settings['ang_container_padding'];
-			} else {
-				// Get default items, but without empty defaults.
-				$control       = $kit->get_controls( 'ang_container_padding' );
-				$padding_items = $control['default'];
-			}
+			foreach ( $controls as $control ) {
+				// Get SK Container padding preset labels.
+				if ( isset( $kit_raw_settings[ $control ] ) ) {
+					$padding_items = $kit_raw_settings[ $control ];
+				} else {
+					// Get default items, but without empty defaults.
+					$control       = $kit->get_controls( $control );
+					$padding_items = $control['default'];
+				}
 
-			foreach ( $padding_items as $padding ) {
-				$options[ $padding['_id'] ] = $padding['title'];
+				foreach ( $padding_items as $padding ) {
+					if ( isset( $padding['padding'] ) || isset( $padding['padding_tablet'] ) || isset( $padding['padding_mobile'] ) ) {
+						$options[ $padding['_id'] ] = $padding['title'];
+					}
+				}
 			}
 		}
 

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -515,6 +515,18 @@ class Typography extends Module {
 					'isLinked' => true,
 				),
 			),
+			array(
+				'_id'   => 'ang_container_padding_6',
+				'title' => __( 'style 6', 'ang' ),
+			),
+			array(
+				'_id'   => 'ang_container_padding_7',
+				'title' => __( 'style 7', 'ang' ),
+			),
+			array(
+				'_id'   => 'ang_container_padding_8',
+				'title' => __( 'style 8', 'ang' ),
+			),
 		);
 
 		$repeater = new Repeater();
@@ -554,37 +566,6 @@ class Typography extends Module {
 				'type'         => Global_Style_Repeater::CONTROL_TYPE,
 				'fields'       => $repeater->get_controls(),
 				'default'      => $padding_defaults,
-				'item_actions' => array(
-					'add'       => false,
-					'remove'    => false,
-					'sort'      => false,
-					'duplicate' => false,
-				),
-				'separator'    => 'after',
-			)
-		);
-
-		$padding_defaults_part_two = array(
-			array(
-				'_id'   => 'ang_container_padding_6',
-				'title' => __( 'style 6', 'ang' ),
-			),
-			array(
-				'_id'   => 'ang_container_padding_7',
-				'title' => __( 'style 7', 'ang' ),
-			),
-			array(
-				'_id'   => 'ang_container_padding_8',
-				'title' => __( 'style 8', 'ang' ),
-			),
-		);
-
-		$element->add_control(
-			'ang_container_padding_part_two',
-			array(
-				'type'         => Global_Style_Repeater::CONTROL_TYPE,
-				'fields'       => $repeater->get_controls(),
-				'default'      => $padding_defaults_part_two,
 				'item_actions' => array(
 					'add'       => false,
 					'remove'    => false,

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -1230,12 +1230,14 @@ class Typography extends Module {
 				} else {
 					// Get default items, but without empty defaults.
 					$control       = $kit->get_controls( $control );
-					$padding_items = $control['default'];
+					$padding_items = $control['default'] ?? array();
 				}
 
-				foreach ( $padding_items as $padding ) {
-					if ( isset( $padding['padding'] ) || isset( $padding['padding_tablet'] ) || isset( $padding['padding_mobile'] ) ) {
-						$options[ $padding['_id'] ] = $padding['title'];
+				if ( ! empty( $padding_items ) ) {
+					foreach ( $padding_items as $padding ) {
+						if ( isset( $padding['padding'] ) || isset( $padding['padding_tablet'] ) || isset( $padding['padding_mobile'] ) ) {
+							$options[ $padding['_id'] ] = $padding['title'];
+						}
 					}
 				}
 			}

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -1550,6 +1550,13 @@ class Typography extends Module {
 			)
 		);
 
+		$element->start_controls_tabs( 'ang_global_fonts_section_tabs' );
+
+		$element->start_controls_tab(
+			'ang_tab_global_fonts_primary',
+			array( 'label' => __( '1-16', 'ang' ) )
+		);
+
 		$repeater = new Repeater();
 
 		$repeater->add_control(
@@ -1718,6 +1725,12 @@ class Typography extends Module {
 				'separator'    => 'after',
 			)
 		);
+
+		$element->end_controls_tab();
+
+		do_action( 'analog_global_fonts_tab_end', $element, $repeater );
+
+		$element->end_controls_tabs();
 
 		$element->add_control(
 			'ang_global_reset_fonts',

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -93,6 +93,7 @@ class Typography extends Module {
 		$container_spacing_experiment = Options::get_instance()->get( 'container_spacing_experiment' );
 
 		if ( 'active' === $container_spacing_experiment ) {
+			add_action( 'elementor/element/kit/section_settings-layout/before_section_end', array( $this, 'show_analog_container_spacing_hint' ), 10, 2 );
 			add_action( 'elementor/element/kit/section_buttons/after_section_end', array( $this, 'register_container_spacing' ), 50, 2 );
 			add_action( 'elementor/element/container/section_layout_container/before_section_end', array( $this, 'tweak_container_widget' ) );
 		}
@@ -627,6 +628,46 @@ class Typography extends Module {
 		);
 
 		$element->end_controls_section();
+	}
+
+	/**
+	 * Show hint for Style Kit Container spacing presets.
+	 *
+	 * @param Controls_Stack $element Controls object.
+	 * @param string         $section_id Section ID.
+	 */
+	public function show_analog_container_spacing_hint( Controls_Stack $element, $section_id ) {
+		$element->start_injection(
+			array(
+				'of' => 'container_padding',
+				'at' => 'after',
+			)
+		);
+
+		$element->add_control(
+			'analog_container_padding_hint',
+			array(
+				'raw'             => sprintf(
+					'%1$s <a href="#" onClick="%2$s">%3$s</a>',
+					__( 'Create additional spacing presets in ', 'ang' ),
+					"analog.redirectToSection( 'theme-style-kits', 'ang_container_spacing', 'global' )",
+					__( 'Style Kits', 'ang' ),
+				),
+				'type'            => Controls_Manager::RAW_HTML,
+				'content_classes' => 'elementor-descriptor',
+				'separator'       => 'before',
+			)
+		);
+
+		$element->add_control(
+			'analog_container_padding_hint_separator',
+			array(
+				'type'  => Controls_Manager::DIVIDER,
+				'style' => 'thick',
+			)
+		);
+
+		$element->end_injection();
 	}
 
 	/**

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -393,19 +393,52 @@ class Typography extends Module {
 		);
 
 		$element->add_control(
-			'ang_container_padding_description',
+			'ang_container_default_padding_hint',
 			array(
 				'raw'             => sprintf(
-					'%1$s <a href="https://docs.analogwp.com/article/655-container-presets" target="_blank">%2$s</a>',
-					__( 'Save padding presets for containers.', 'ang' ),
-					__( 'Read more', 'ang' ),
+					'%1$s <a href="#" onClick="%2$s">%3$s</a>',
+					__( 'The default container padding is set in Elementor Theme Styles > Layout Settings > ', 'ang' ),
+					"analog.redirectToSection( 'settings-layout', 'section_settings-layout', 'global' )",
+					__( 'Container padding', 'ang' ),
 				),
 				'type'            => Controls_Manager::RAW_HTML,
 				'content_classes' => 'elementor-descriptor',
 			)
 		);
 
-		$element->start_controls_tabs( 'ang_container_spacing_tabs' );
+		$element->add_control(
+			'ang_container_padding_description',
+			array(
+				'raw'             => sprintf(
+					'%1$s <a href="https://docs.analogwp.com/article/655-container-presets" target="_blank">%2$s</a>',
+					__( 'Create additional spacing presets.', 'ang' ),
+					__( 'Read more', 'ang' ),
+				),
+				'type'            => Controls_Manager::RAW_HTML,
+				'content_classes' => 'elementor-descriptor',
+				'separator'       => 'before',
+			)
+		);
+
+		// Hack for adding no padding styles at container presets.
+		$element->add_control(
+			'ang_container_no_padding_hidden',
+			array(
+				'label'     => __( 'No Padding Styles', 'ang' ),
+				'type'      => Controls_Manager::HIDDEN,
+				'default'   => 'no',
+				'selectors' => array(
+					'{{WRAPPER}} .elementor-repeater-item-ang_container_no_padding.elementor-element' => '--padding-top: 0px; --padding-right: 0px; --padding-bottom: 0px; --padding-left: 0px;',
+				),
+			)
+		);
+
+		$element->start_controls_tabs(
+			'ang_container_spacing_tabs',
+			array(
+			'separator'       => 'before',
+			)
+		);
 
 		$element->start_controls_tab(
 			'ang_tab_container_spacing_primary',
@@ -1183,7 +1216,8 @@ class Typography extends Module {
 
 		// Register default options array.
 		$options = array(
-			'none' => __( 'None', 'ang' ),
+			'none'                     => __( 'Default', 'ang' ),
+			'ang_container_no_padding' => __( 'No Padding', 'ang' ),
 		);
 
 		/**

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -572,7 +572,6 @@ class Typography extends Module {
 					'sort'      => false,
 					'duplicate' => false,
 				),
-				'separator'    => 'after',
 			)
 		);
 

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -1269,7 +1269,6 @@ class Typography extends Module {
 		if ( $kit ) {
 			$controls = array(
 				'ang_container_padding',
-				'ang_container_padding_part_two',
 				'ang_container_padding_secondary',
 				'ang_container_padding_tertiary',
 				'ang_custom_container_padding',

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -392,6 +392,28 @@ class Typography extends Module {
 			)
 		);
 
+		$element->add_control(
+			'ang_container_padding_description',
+			array(
+				'raw'             => sprintf(
+					'%1$s <a href="https://docs.analogwp.com/article/655-container-presets" target="_blank">%2$s</a>',
+					__( 'Save padding presets for containers.', 'ang' ),
+					__( 'Read more', 'ang' ),
+				),
+				'type'            => Controls_Manager::RAW_HTML,
+				'content_classes' => 'elementor-descriptor',
+			)
+		);
+
+		$element->start_controls_tabs( 'ang_container_spacing_tabs' );
+
+		$element->start_controls_tab(
+			'ang_tab_container_spacing_primary',
+			array(
+				'label' => __( '1-8', 'ang' ),
+			)
+		);
+
 		$padding_defaults = array(
 			array(
 				'_id'            => 'ang_container_padding_1',
@@ -495,27 +517,6 @@ class Typography extends Module {
 			),
 		);
 
-		$element->add_control(
-			'ang_container_padding_description',
-			array(
-				'raw'             => sprintf(
-					'%1$s <a href="https://docs.analogwp.com/article/655-container-presets" target="_blank">%2$s</a>',
-					__( 'Save padding presets for containers.', 'ang' ),
-					__( 'Read more', 'ang' ),
-				),
-				'type'            => Controls_Manager::RAW_HTML,
-				'content_classes' => 'elementor-descriptor',
-			)
-		);
-
-		$element->add_control(
-			'ang_container_padding_heading',
-			array(
-				'type'  => Controls_Manager::HEADING,
-				'label' => esc_html__( 'System Presets', 'ang' ),
-			)
-		);
-
 		$repeater = new Repeater();
 
 		$repeater->add_control(
@@ -562,6 +563,43 @@ class Typography extends Module {
 				'separator'    => 'after',
 			)
 		);
+
+		$padding_defaults_part_two = array(
+			array(
+				'_id'   => 'ang_container_padding_6',
+				'title' => __( 'style 6', 'ang' ),
+			),
+			array(
+				'_id'   => 'ang_container_padding_7',
+				'title' => __( 'style 7', 'ang' ),
+			),
+			array(
+				'_id'   => 'ang_container_padding_8',
+				'title' => __( 'style 8', 'ang' ),
+			),
+		);
+
+		$element->add_control(
+			'ang_container_padding_part_two',
+			array(
+				'type'         => Global_Style_Repeater::CONTROL_TYPE,
+				'fields'       => $repeater->get_controls(),
+				'default'      => $padding_defaults_part_two,
+				'item_actions' => array(
+					'add'       => false,
+					'remove'    => false,
+					'sort'      => false,
+					'duplicate' => false,
+				),
+				'separator'    => 'after',
+			)
+		);
+
+		$element->end_controls_tab();
+
+		do_action( 'analog_container_spacing_tabs_end', $element, $repeater );
+
+		$element->end_controls_tabs();
 
 		do_action( 'analog_container_spacing_section_end', $element, $repeater );
 

--- a/inc/elementor/globals/class-colors.php
+++ b/inc/elementor/globals/class-colors.php
@@ -49,6 +49,10 @@ class Colors extends Base {
 			'ang_global_accent_colors',
 			'ang_global_text_colors',
 			'ang_global_extra_colors',
+			'ang_global_secondary_part_one_colors',
+			'ang_global_secondary_part_two_colors',
+			'ang_global_tertiary_part_one_colors',
+			'ang_global_tertiary_part_two_colors',
 		);
 
 		foreach ( $color_keys as $color_key ) {

--- a/inc/elementor/globals/class-colors.php
+++ b/inc/elementor/globals/class-colors.php
@@ -69,8 +69,8 @@ class Colors extends Base {
 			$id            = $item['_id'];
 			$result[ $id ] = array(
 				'id'    => $id,
-				'title' => $item['title'],
-				'value' => $item['color'],
+				'title' => $item['title'] ?? '',
+				'value' => $item['color'] ?? '',
 			);
 		}
 

--- a/inc/elementor/globals/class-typography.php
+++ b/inc/elementor/globals/class-typography.php
@@ -54,6 +54,10 @@ class Typography extends Base {
 		$font_keys = array(
 			'ang_global_title_fonts',
 			'ang_global_text_fonts',
+			'ang_global_secondary_part_one_fonts',
+			'ang_global_secondary_part_two_fonts',
+			'ang_global_tertiary_part_one_fonts',
+			'ang_global_tertiary_part_two_fonts',
 		);
 
 		foreach ( $font_keys as $font_key ) {

--- a/inc/elementor/globals/class-typography.php
+++ b/inc/elementor/globals/class-typography.php
@@ -91,7 +91,7 @@ class Typography extends Base {
 			$id = $item['_id'];
 
 			$result[ $id ] = array(
-				'title' => $item['title'],
+				'title' => $item['title'] ?? '',
 				'id'    => $id,
 			);
 

--- a/inc/elementor/js/ang-action.js
+++ b/inc/elementor/js/ang-action.js
@@ -541,6 +541,10 @@ jQuery( window ).on( 'elementor/init', function() {
 				'ang_global_accent_colors',
 				'ang_global_text_colors',
 				'ang_global_extra_colors',
+				'ang_global_secondary_part_one_colors',
+				'ang_global_secondary_part_two_colors',
+				'ang_global_tertiary_part_one_colors',
+				'ang_global_tertiary_part_two_colors',
 			];
 
 		let defaultValues = {};
@@ -578,6 +582,10 @@ jQuery( window ).on( 'elementor/init', function() {
 		const ang_global_fonts = [
 			'ang_global_title_fonts',
 			'ang_global_text_fonts',
+			'ang_global_secondary_part_one_fonts',
+			'ang_global_secondary_part_two_fonts',
+			'ang_global_tertiary_part_one_fonts',
+			'ang_global_tertiary_part_two_fonts',
 		];
 
 		let defaultValues = {};

--- a/inc/elementor/js/ang-action.js
+++ b/inc/elementor/js/ang-action.js
@@ -196,9 +196,9 @@ jQuery( window ).on( 'elementor/init', function() {
 		return ! ( key.startsWith( 'ang_action' ) || key.startsWith( 'post' ) || key.startsWith( 'preview' ) );
 	};
 
-	analog.redirectToSection = function redirectToSection( tab = 'settings', section = 'ang_style_settings', page = 'page_settings' ) {
-		$e.route( `panel/page-settings/${ tab }` );
-		elementor.getPanelView().getCurrentPageView().activateSection('ang_style_settings')._renderChildren();
+	analog.redirectToSection = function redirectToSection( tab = 'settings', section = 'ang_style_settings', page = 'page-settings' ) {
+		$e.route( `panel/${ page }/${ tab }` );
+		elementor.getPanelView().getCurrentPageView().content.currentView.activateSection(section).render();
 
 		return false;
 	};

--- a/inc/elementor/js/ang-action.js
+++ b/inc/elementor/js/ang-action.js
@@ -622,13 +622,22 @@ jQuery( window ).on( 'elementor/init', function() {
 	analog.resetContainerPadding = () => {
 		const ang_container_padding = [
 			'ang_container_padding',
+			'ang_container_padding_part_two',
+			'ang_container_padding_secondary',
+			'ang_container_padding_tertiary',
 			'ang_custom_container_padding',
 		];
 
 		let defaultValues = {};
 
 		// Get defaults for each setting
-		ang_container_padding.forEach( ( setting ) => defaultValues[ setting ] = elementor.documents.documents[elementor.config.kit_id].container.controls[setting].default );
+		ang_container_padding.forEach( ( setting ) => {
+			const options = elementor.documents.documents[elementor.config.kit_id].container.controls[setting];
+			if ( undefined === options || null === options ) {
+				return;
+			}
+			defaultValues[ setting ] = options.default;
+		} );
 
 		// Reset the selected settings to their default values
 		$e.run( 'document/elements/settings', {


### PR DESCRIPTION
### How to test
1. Make sure to activate Style Kit Container spacing option at Style Kits >> Settings and then Experiments.
2. Go to Elementor editor screen, open Site settings.
3. From Site settings, go to Style Kits >> Container Spacing.
4. Add/update a few options and select them at Container widget >> Spacing Preset control.
5. Test Reset button, it should reset options to their default state.