### PR TITLE
Release v2.0.5

### DIFF
--- a/analogwp-templates.php
+++ b/analogwp-templates.php
@@ -10,14 +10,14 @@
  * Plugin Name: Style Kits for Elementor
  * Plugin URI:  https://analogwp.com/
  * Description: Style Kits extends the Elementor theme styles editor with more global styling options. Boost your design workflow in Elementor with intuitive global controls and theme style presets.
- * Version:     2.0.4
+ * Version:     2.0.5
  * Author:      AnalogWP
  * Author URI:  https://analogwp.com/
  * License:     GPL2
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: ang
- * Elementor tested up to: 3.13.2
- * Elementor Pro tested up to: 3.13.1
+ * Elementor tested up to: 3.14.1
+ * Elementor Pro tested up to: 3.14.1
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'ANG_ELEMENTOR_MINIMUM', '3.5.0' );
 define( 'ANG_PHP_MINIMUM', '7.0' );
 define( 'ANG_WP_MINIMUM', '5.9' );
-define( 'ANG_VERSION', '2.0.4' );
+define( 'ANG_VERSION', '2.0.5' );
 define( 'ANG_PLUGIN_FILE', __FILE__ );
 define( 'ANG_PLUGIN_URL', plugin_dir_url( ANG_PLUGIN_FILE ) );
 define( 'ANG_PLUGIN_DIR', plugin_dir_path( ANG_PLUGIN_FILE ) );

--- a/inc/Database_Upgrader.php
+++ b/inc/Database_Upgrader.php
@@ -36,6 +36,7 @@ class Database_Upgrader {
 			'1.7.0' => 'upgrade_1_7',
 			'1.7.2' => 'upgrade_1_7_2',
 			'2.0.0' => 'upgrade_2_0',
+			'2.0.5' => 'upgrade_2_0_5',
 		);
 
 		$version = get_option( self::OPTION, '0.0.0' );

--- a/inc/Database_Upgrader.php
+++ b/inc/Database_Upgrader.php
@@ -150,7 +150,7 @@ class Database_Upgrader {
 					continue;
 				}
 
-				$control           = $kit->get_controls( $control_key );
+				$control = $kit->get_controls( $control_key );
 
 				$default_controls = $control['default'];
 				$updated_settings = $default_controls;
@@ -166,9 +166,9 @@ class Database_Upgrader {
 				'settings' => $kit_raw_settings,
 			);
 
-			 $kit->save( $data );
+			$kit->save( $data );
 		}
 		// Regenerate Elementor CSS.
-		 Utils::clear_elementor_cache();
+		Utils::clear_elementor_cache();
 	}
 }

--- a/inc/Utils.php
+++ b/inc/Utils.php
@@ -816,6 +816,46 @@ class Utils extends Base {
 		$status = Options::get_instance()->get( 'ang_license_key_status' );
 		return self::has_pro() && 'valid' === $status;
 	}
+
+	/**
+	 * Returns sanitized super global value from super globals if exists.
+	 *
+	 * @since 2.0.5
+	 *
+	 * @param $super_global
+	 * @param $key
+	 * @return mixed|null
+	 */
+	public static function get_super_global_value( $super_global, $key ) {
+		if ( ! isset( $super_global[ $key ] ) ) {
+			return null;
+		}
+
+		if ( $_FILES === $super_global ) {
+			$super_global[ $key ]['name'] = sanitize_file_name( $super_global[ $key ]['name'] );
+
+			return $super_global[ $key ];
+		}
+
+		return wp_kses_post_deep( wp_unslash( $super_global[ $key ] ) );
+	}
+
+	/**
+	 * Returns file content.
+	 *
+	 * @since 2.0.5
+	 *
+	 * @param $file
+	 * @param mixed ...$args
+	 * @return false|string
+	 */
+	public static function file_get_contents( $file, ...$args ) {
+		if ( ! is_file( $file ) || ! is_readable( $file ) ) {
+			return false;
+		}
+
+		return file_get_contents( $file, ...$args );
+	}
 }
 
 new Utils();

--- a/inc/elementor/kit/Kits_List_Table.php
+++ b/inc/elementor/kit/Kits_List_Table.php
@@ -245,11 +245,10 @@ class Kits_List_Table extends \WP_List_Table {
 	private function get_export_link( $id ) {
 		return add_query_arg(
 			array(
-				'action'         => 'elementor_library_direct_actions',
-				'library_action' => 'export_template',
-				'source'         => 'local',
-				'_nonce'         => wp_create_nonce( 'elementor_ajax' ),
-				'template_id'    => $id,
+				'action'         => 'stylekits_library_direct_actions',
+				'library_action' => 'export_kit',
+				'_nonce'         => wp_create_nonce( 'stylekits_ajax' ),
+				'kit_id'    => $id,
 			),
 			admin_url( 'admin-ajax.php' )
 		);

--- a/inc/elementor/kit/Kits_List_Table.php
+++ b/inc/elementor/kit/Kits_List_Table.php
@@ -351,8 +351,9 @@ function ang_kits_list() {
 		<div id="analog-import-template-area" style="display: none; margin: 50px 0 30px; text-align: center;">
 			<div id="analog-import-template-title" style="font-size: 18px; color: #555d66;"><?php echo esc_html__( 'Choose an Elementor template JSON file or a .zip archive of Elementor templates, and add them to the list of templates available in your library.', 'ang' ); ?></div>
 			<form id="analog-import-template-form" style="display: inline-block;margin-top: 30px;padding: 30px 50px;background-color: #FFFFFF;border: 1px solid #e5e5e5;" method="post" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" enctype="multipart/form-data">
-				<input type="hidden" name="action" value="analog_local_kits_import">
-				<input type="hidden" name="_nonce" value="<?php echo wp_create_nonce( 'analog_local_kits_import_nonce' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>">
+				<input type="hidden" name="action" value="stylekits_library_direct_actions">
+				<input type="hidden" name="library_action" value="import_local_kit">
+				<input type="hidden" name="_nonce" value="<?php echo wp_create_nonce( 'stylekits_ajax' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>">
 				<fieldset id="elementor-import-template-form-inputs">
 					<input type="file" name="file" accept=".json,application/json,.zip,application/octet-stream,application/zip,application/x-zip,application/x-zip-compressed" required="">
 					<input id="analog-import-template-action" type="submit" class="button" value="<?php echo esc_attr__( 'Import Now', 'ang' ); ?>">

--- a/inc/elementor/kit/Manager.php
+++ b/inc/elementor/kit/Manager.php
@@ -424,7 +424,7 @@ class Manager {
 	}
 
 	/**
-	 * Process a Style Kit import.
+	 * Process a Style Kit remote import.
 	 *
 	 * @since 1.9.6
 	 *
@@ -448,8 +448,18 @@ class Manager {
 			return new WP_Error( 'kit_import_request_error', __( 'Error occured while requesting Style Kit data.', 'ang' ) );
 		}
 
-		$kit_data     = $remote_kit['data'];
-		$kit_settings = maybe_unserialize( $kit_data );
+		return $this->direct_kit_import( $remote_kit );
+	}
+
+	/**
+	 * Import kit.
+	 *
+	 * @param array $kit Array containing Style Kit info to import.
+	 *
+	 * @return WP_Error|array
+	 */
+	public function direct_kit_import( $kit ) {
+		$kit_settings = maybe_unserialize( $kit['data'] );
 
 		$kit_id = $this->create_kit(
 			$kit['title'],

--- a/inc/elementor/kit/Manager.php
+++ b/inc/elementor/kit/Manager.php
@@ -513,6 +513,8 @@ class Manager {
 
 		$remote_kit = Remote::get_instance()->get_stylekit_data( $kit );
 
+		$remote_kit['title'] = $kit['title'] ?? '';
+
 		if ( isset( $remote_kit['message'], $remote_kit['code'] ) ) {
 			return new WP_Error( $remote_kit['code'], $remote_kit['message'] );
 		}

--- a/inc/elementor/kit/Manager.php
+++ b/inc/elementor/kit/Manager.php
@@ -128,7 +128,7 @@ class Manager {
 
 			wp_trash_post( $kit_id );
 
-			wp_safe_redirect( admin_url() . "admin.php?page=style-kits&trashed=${kit_id}" );
+			wp_safe_redirect( admin_url() . "admin.php?page=style-kits&trashed={$kit_id}" );
 			exit();
 		}
 	}

--- a/inc/elementor/kit/Manager.php
+++ b/inc/elementor/kit/Manager.php
@@ -201,6 +201,60 @@ class Manager {
 	}
 
 	/**
+	 * Process a Style kit local import.
+	 *
+	 * @since 2.0.5
+	 *
+	 * @param array $args Kit arguments.
+	 *
+	 * @return mixed Whether the export succeeded or failed.
+	 */
+	public function import_local_kit( array $args ) {
+		$file = Utils::get_super_global_value( $_FILES, 'file' );
+
+		if ( empty( $file ) ) {
+			return new \WP_Error( 'file_error', 'Please upload a file to import' );
+		}
+
+		return $this->process_uploaded_kit( $file['tmp_name'] );
+
+	}
+
+	/**
+	 * Import template from a file.
+	 *
+	 * @since 2.0.5
+	 * @access public
+	 *
+	 * @param string $path - The file path.
+	 *
+	 * @return \WP_Error|array An array of items on success, 'WP_Error' on failure.
+	 */
+	public function process_uploaded_kit( $path ) {
+		// @todo: Maybe handle multi-uploads.
+		// If the import file is a single JSON file.
+		$data = json_decode( Utils::file_get_contents( $path ), true );
+
+		if ( empty( $data ) ) {
+			return new \WP_Error( 'file_error', 'Invalid File' );
+		}
+
+		$content = maybe_unserialize( $data['data'] );
+
+		if ( ! is_array( $content ) ) {
+			return new \WP_Error( 'file_error', 'Invalid Content In File' );
+		}
+
+		$kit_id = $this->direct_kit_import( $data );
+
+		if ( is_wp_error( $kit_id ) ) {
+			return $kit_id;
+		}
+
+		return get_post( $kit_id );
+	}
+
+	/**
 	 * Export a kit.
 	 *
 	 * @since 2.0.5

--- a/inc/elementor/kit/Manager.php
+++ b/inc/elementor/kit/Manager.php
@@ -66,6 +66,8 @@ class Manager {
 
 		add_action( 'wp_ajax_analog_local_kits_import', array( $this, 'handle_template_import' ) );
 
+		add_action( 'wp_ajax_stylekits_library_direct_actions', array( $this, 'handle_library_actions' ) );
+
 		add_filter(
 			'analog_admin_notices',
 			function( $notices ) {
@@ -161,6 +163,35 @@ class Manager {
 		$result = Plugin::elementor()->templates_manager->direct_import_template();
 
 		if ( is_wp_error( $result ) ) {
+			$this->handle_error( $result->get_error_message() . '.' );
+		}
+
+		wp_safe_redirect( admin_url( 'admin.php?page=style-kits' ) );
+
+		die;
+	}
+
+	/**
+	 * Handle local kits library actions.
+	 *
+	 * @since 2.0.5
+	 * @return void
+	 */
+	public function handle_library_actions() {
+		if ( ! User::is_current_user_can_edit_post_type( Source_Local::CPT ) ) {
+			return;
+		}
+
+		if ( ! check_ajax_referer( 'stylekits_ajax', '_nonce' ) ) {
+			$this->handle_error( 'Access Denied' );
+		}
+
+		$action = Utils::get_super_global_value( $_REQUEST, 'library_action' ); // phpcs:ignore -- Nonce already verified.
+
+		$result = $this->$action( $_REQUEST ); // phpcs:ignore -- Nonce already verified.
+
+		if ( is_wp_error( $result ) ) {
+			/** @var \WP_Error $result */
 			$this->handle_error( $result->get_error_message() . '.' );
 		}
 

--- a/inc/elementor/kit/Manager.php
+++ b/inc/elementor/kit/Manager.php
@@ -55,9 +55,12 @@ class Manager {
 		add_filter( 'body_class', array( $this, 'should_remove_global_kit_class' ), 999 );
 		add_action( 'delete_post', array( $this, 'restore_default_kit' ) );
 
-		add_action( 'wp_trash_post', function ( $post_id ) {
-			$this->before_delete_kit( $post_id );
-		} );
+		add_action(
+			'wp_trash_post',
+			function ( $post_id ) {
+				$this->before_delete_kit( $post_id );
+			}
+		);
 
 		add_action( 'wp_ajax_nopriv_ang_global_kit', array( $this, 'update_global_kit' ) );
 		add_action( 'wp_ajax_ang_global_kit', array( $this, 'update_global_kit' ) );
@@ -331,7 +334,7 @@ class Manager {
 	 * Send a confirm message before move a kit to trash, or if delete permanently not for trash.
 	 *
 	 * @param       $post_id
-	 * @param false $is_permanently_delete
+	 * @param false   $is_permanently_delete
 	 */
 	private function before_delete_kit( $post_id ) {
 		$document = Plugin::elementor()->documents->get( $post_id );

--- a/languages/ang.pot
+++ b/languages/ang.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the GPL2.
 msgid ""
 msgstr ""
-"Project-Id-Version: Style Kits for Elementor 2.0.4\n"
+"Project-Id-Version: Style Kits for Elementor 2.0.5\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/analogwp-templates\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-05-17T03:28:03+00:00\n"
+"POT-Creation-Date: 2023-07-05T08:54:20+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.6.0\n"
+"X-Generator: WP-CLI 2.8.1\n"
 "X-Domain: ang\n"
 
 #. Plugin Name of the plugin
@@ -201,7 +201,7 @@ msgid "Welcome to Style Kits"
 msgstr ""
 
 #: inc/class-onboarding.php:82
-#: inc/elementor/kit/Kits_List_Table.php:342
+#: inc/elementor/kit/Kits_List_Table.php:341
 msgid "Working..."
 msgstr ""
 
@@ -316,7 +316,7 @@ msgid "Skip wizard"
 msgstr ""
 
 #: inc/class-onboarding.php:271
-#: inc/elementor/kit/Kits_List_Table.php:343
+#: inc/elementor/kit/Kits_List_Table.php:342
 #: inc/elementor/kit/Kits_List_Table.php:377
 msgid "Apply"
 msgstr ""
@@ -1307,13 +1307,13 @@ msgid "Edit with Elementor"
 msgstr ""
 
 #: inc/elementor/kit/Instance_List_Table.php:281
-#: inc/elementor/kit/Kits_List_Table.php:267
+#: inc/elementor/kit/Kits_List_Table.php:266
 msgid "Move to Trash"
 msgstr ""
 
 #. translators: %s: Number of posts.
 #: inc/elementor/kit/Instance_List_Table.php:297
-#: inc/elementor/kit/Kits_List_Table.php:285
+#: inc/elementor/kit/Kits_List_Table.php:284
 msgctxt "posts"
 msgid "All <span class=\"count\">(%s)</span>"
 msgid_plural "All <span class=\"count\">(%s)</span>"
@@ -1357,7 +1357,7 @@ msgstr ""
 msgid "Export Theme Style Kit"
 msgstr ""
 
-#: inc/elementor/kit/Kits_List_Table.php:349
+#: inc/elementor/kit/Kits_List_Table.php:348
 #: inc/register-settings.php:57
 #: inc/register-settings.php:58
 #: inc/settings/class-settings-general.php:83
@@ -1366,7 +1366,7 @@ msgstr ""
 msgid "Local Style Kits"
 msgstr ""
 
-#: inc/elementor/kit/Kits_List_Table.php:353
+#: inc/elementor/kit/Kits_List_Table.php:352
 msgid "Choose an Elementor template JSON file or a .zip archive of Elementor templates, and add them to the list of templates available in your library."
 msgstr ""
 
@@ -1378,19 +1378,19 @@ msgstr ""
 msgid "A list of all the imported and custom Style Kits. A global Style Kit is the one that applies globally on your site. You can set a Global Style Kit below."
 msgstr ""
 
-#: inc/elementor/kit/Manager.php:417
+#: inc/elementor/kit/Manager.php:580
 msgid "Error occured while requesting Style Kit data."
 msgstr ""
 
-#: inc/elementor/kit/Manager.php:437
+#: inc/elementor/kit/Manager.php:610
 msgid "Style Kit imported"
 msgstr ""
 
-#: inc/elementor/kit/Manager.php:498
+#: inc/elementor/kit/Manager.php:671
 msgid "All good! The Style Kit has been set as Global."
 msgstr ""
 
-#: inc/elementor/kit/Manager.php:500
+#: inc/elementor/kit/Manager.php:673
 msgid "View site"
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mauryaratan/analogwp-templates.git"
+    "url": "git+https://github.com/analogwp/analogwp-templates.git"
   },
   "author": "Ram Ratan Maurya",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/mauryaratan/analogwp-templates/issues"
+    "url": "https://github.com/analogwp/analogwp-templates/issues"
   },
-  "homepage": "https://github.com/mauryaratan/analogwp-templates#readme",
+  "homepage": "https://github.com/analogwp/analogwp-templates#readme",
   "dependencies": {
     "classnames": "^2.2.6",
     "react-masonry-css": "^1.0.14",

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: analogwp, mauryaratan
 Requires at least: 5.9
 Requires PHP: 7.0
-Tested up to: 6.2.1
-Stable tag: 2.0.4
+Tested up to: 6.2.2
+Stable tag: 2.0.5
 Tags: elementor, patterns, global styles, elementor addons, design system
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,15 @@ We offer high-level support for all Style Kits users. Reach out to https://analo
 
 == Changelog ==
 
+= 2.0.5 - July 05, 2023 =
+* New: Added new method to support Kit Import/Export via Local Kits library
+* Fix: Warnings at editor for missing `active_breakpoints` data in kits
+* Fix: Warning at Kit trashing action for string interpolation
+* Improvements: Compatibility with Elementor v3.14.1 and Elementor Pro v3.14.1
+* Improvements: Compatibility with WordPress v6.2.2
+* Improvements: Updated translation files
+* Improvements: Other minor code changes
+
 = 2.0.4 - May 18, 2023 =
 * Fix: Missing translation strings
 * Improvements: Remove unused utility functions

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,12 +1149,12 @@ agent-base@6, agent-base@^6.0.2:
     debug "4"
 
 agentkeepalive@^4.1.3, agentkeepalive@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.2.1.tgz#a7975cbb9f83b367f06c90cc51ff28fe7d499717"
-  integrity sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.3.0.tgz#bb999ff07412653c1803b3ced35e50729830a255"
+  integrity sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==
   dependencies:
     debug "^4.1.0"
-    depd "^1.1.2"
+    depd "^2.0.0"
     humanize-ms "^1.2.1"
 
 aggregate-error@^3.0.0:
@@ -2827,10 +2827,10 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-depd@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
-  integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
+depd@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 des.js@^1.0.0:
   version "1.0.0"
@@ -3935,9 +3935,9 @@ glob@^7.1.4:
     path-is-absolute "^1.0.0"
 
 glob@^8.0.1:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
-  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -4032,9 +4032,9 @@ graceful-fs@^4.2.2:
   integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
 
 graceful-fs@^4.2.6:
-  version "4.2.10"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
-  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
 gulp-babel@8.0.0:
   version "8.0.0"
@@ -4336,9 +4336,9 @@ hosted-git-info@^4.0.1:
     lru-cache "^6.0.0"
 
 http-cache-semantics@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
-  integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
+  integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
 
 http-proxy-agent@^4.0.1:
   version "4.0.1"
@@ -5563,9 +5563,9 @@ lru-cache@^6.0.0:
     yallist "^4.0.0"
 
 lru-cache@^7.7.1:
-  version "7.14.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.1.tgz#8da8d2f5f59827edb388e63e459ac23d6d408fea"
-  integrity sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
+  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
 
 make-dir@^2.0.0:
   version "2.1.0"
@@ -5810,9 +5810,9 @@ minimatch@^3.1.1:
     brace-expansion "^1.1.7"
 
 minimatch@^5.0.1:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
-  integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -5893,12 +5893,24 @@ minipass@^2.2.1, minipass@^2.3.4:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
-minipass@^3.0.0, minipass@^3.1.0, minipass@^3.1.1, minipass@^3.1.3, minipass@^3.1.6:
+minipass@^3.0.0:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.3.4.tgz#ca99f95dd77c43c7a76bf51e6d200025eee0ffae"
   integrity sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==
   dependencies:
     yallist "^4.0.0"
+
+minipass@^3.1.0, minipass@^3.1.1, minipass@^3.1.3, minipass@^3.1.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.3.6.tgz#7bba384db3a1520d18c9c0e5251c3444e95dd94a"
+  integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
+  dependencies:
+    yallist "^4.0.0"
+
+minipass@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
+  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
 
 minizlib@^1.1.1:
   version "1.2.1"
@@ -7167,9 +7179,9 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable
     util-deprecate "~1.0.1"
 
 readable-stream@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -7662,10 +7674,17 @@ semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.4, semver@^7.3.5:
+semver@^7.3.4:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.5:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
+  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -8242,7 +8261,7 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
-tar@^6.0.2, tar@^6.1.11, tar@^6.1.2:
+tar@^6.0.2:
   version "6.1.12"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.12.tgz#3b742fb05669b55671fb769ab67a7791ea1a62e6"
   integrity sha512-jU4TdemS31uABHd+Lt5WEYJuzn+TJTCBLljvIAHZOz6M9Os5pJ4dD+vRFLxPa/n3T0iEFzpi+0x1UfuDZYbRMw==
@@ -8250,6 +8269,18 @@ tar@^6.0.2, tar@^6.1.11, tar@^6.1.2:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
     minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
+tar@^6.1.11, tar@^6.1.2:
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.15.tgz#c9738b0b98845a3b344d334b8fa3041aaba53a69"
+  integrity sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^5.0.0"
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
@@ -8932,7 +8963,7 @@ yargs-parser@^20.2.3:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs-parser@^21.0.0:
+yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
@@ -8952,9 +8983,9 @@ yargs-parser@^7.0.0:
     camelcase "^4.1.0"
 
 yargs@^17.2.1:
-  version "17.6.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.0.tgz#e134900fc1f218bc230192bdec06a0a5f973e46c"
-  integrity sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"
@@ -8962,7 +8993,7 @@ yargs@^17.2.1:
     require-directory "^2.1.1"
     string-width "^4.2.3"
     y18n "^5.0.5"
-    yargs-parser "^21.0.0"
+    yargs-parser "^21.1.1"
 
 yargs@^7.1.0:
   version "7.1.0"


### PR DESCRIPTION
* New: Added new method to support Kit Import/Export via Local Kits library
* Fix: Warnings at the editor for missing `active_breakpoints` data in kits
* Fix: Warning at Kit trashing action for string interpolation
* Improvements: Compatibility with Elementor v3.14.1 and Elementor Pro v3.14.1
* Improvements: Compatibility with WordPress v6.2.2
* Improvements: Updated translation files
* Improvements: Other minor code changes