### PR TITLE
Replace deprecated "Schemes" with the new "Globals"

### DIFF
--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -199,7 +199,9 @@ class Typography extends Module {
 					/* translators: %s: Heading 1-6 type */
 					'label'    => sprintf( __( 'Heading %s', 'ang' ), $i ),
 					'selector' => "{$selector} h{$i}, {$selector} .elementor-widget-heading h{$i}.elementor-heading-title",
-					'scheme'   => \Elementor\Core\Schemes\Typography::TYPOGRAPHY_1,
+					'global' => [
+						'default' => \Elementor\Core\Kits\Documents\Tabs\Global_Typography::TYPOGRAPHY_PRIMARY,
+					],
 				)
 			);
 		}
@@ -245,7 +247,9 @@ class Typography extends Module {
 				'name'     => 'ang_body',
 				'label'    => __( 'Body Typography', 'ang' ),
 				'selector' => '{{WRAPPER}}',
-				'scheme'   => \Elementor\Core\Schemes\Typography::TYPOGRAPHY_3,
+				'global' => [
+					'default' => \Elementor\Core\Kits\Documents\Tabs\Global_Typography::TYPOGRAPHY_TEXT,
+				],
 			)
 		);
 

--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -13,6 +13,7 @@ use Elementor\Core\Base\Module;
 use Elementor\Controls_Manager;
 use Elementor\Controls_Stack;
 use Elementor\Core\Kits\Controls\Repeater as Global_Style_Repeater;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Element_Base;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Box_Shadow;
@@ -200,7 +201,7 @@ class Typography extends Module {
 					'label'    => sprintf( __( 'Heading %s', 'ang' ), $i ),
 					'selector' => "{$selector} h{$i}, {$selector} .elementor-widget-heading h{$i}.elementor-heading-title",
 					'global' => [
-						'default' => \Elementor\Core\Kits\Documents\Tabs\Global_Typography::TYPOGRAPHY_PRIMARY,
+						'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
 					],
 				)
 			);
@@ -248,7 +249,7 @@ class Typography extends Module {
 				'label'    => __( 'Body Typography', 'ang' ),
 				'selector' => '{{WRAPPER}}',
 				'global' => [
-					'default' => \Elementor\Core\Kits\Documents\Tabs\Global_Typography::TYPOGRAPHY_TEXT,
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
 				],
 			)
 		);


### PR DESCRIPTION
The plugin uses deprecated code. This PR replaces deprecated "Schemes" with the new "Globals" 

For more information, see https://developers.elementor.com/docs/deprecations/complex-example/