### PR TITLE
Fix: DOM optimization is always active since Elementor 3.19

### DIFF
--- a/inc/elementor/class-typography.php
+++ b/inc/elementor/class-typography.php
@@ -779,16 +779,20 @@ class Typography extends Module {
 		);
 
 		$elementor_row   = '';
-		$optimized_dom   = get_option( 'elementor_experiment-e_dom_optimization' );
-		$is_optimize_dom = \Elementor\Core\Experiments\Manager::STATE_ACTIVE === $optimized_dom;
 
-		if ( 'default' === $optimized_dom ) {
-			$experiments     = new \Elementor\Core\Experiments\Manager();
-			$is_optimize_dom = $experiments->is_feature_active( 'e_dom_optimization' );
-		}
+		if ( Utils::is_elementor_pre( '3.19.0' ) ) {
 
-		if ( ! $is_optimize_dom ) { // Add row class if DOM optimization is not active.
-			$elementor_row = ' > .elementor-row ';
+			$optimized_dom   = get_option( 'elementor_experiment-e_dom_optimization' );
+			$is_optimize_dom = \Elementor\Core\Experiments\Manager::STATE_ACTIVE === $optimized_dom;
+
+			if ( 'default' === $optimized_dom ) {
+				$experiments     = new \Elementor\Core\Experiments\Manager();
+				$is_optimize_dom = $experiments->is_feature_active( 'e_dom_optimization' );
+			}
+
+			if ( ! $is_optimize_dom ) { // Add row class if DOM optimization is not active.
+				$elementor_row = ' > .elementor-row ';
+			}
 		}
 
 		foreach ( $gaps as $key => $label ) {


### PR DESCRIPTION
Since Elementor 3.19, DOM optimization is always active. So don't rely on old conditional checks, just bypass them completely if Elementor version is 3.19 or greater.

See https://developers.elementor.com/elementor-3-19-developers-update/#:~:text=Experiments%20and%20Features for reference.